### PR TITLE
Peer client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.4.0
+* BroadcastStateMachine: always announces its own PUB url, regardless of the RAFT state.
+* ZmqRaftPeerClient: a single RAFT peer wise client specializing in 0MQ RAFT protocol.
+* ZmqRaftClient: cluster aware client is now built on top of ZmqRaftPeerClient.
+* ZmqRaftPeerSub: a single RAFT peer BroadcastStateMachine client.
+* bin/console.js: new commands: `.cpeer` and `.subp`.
+* ZmqRaftMonitor: urlsOnly option.
+* bin/zmq-monitor.js: new commandline option switches: `-u` and `-p`.
+
 0.3.0
 
 * bin/console.js: external config facility.

--- a/bin/console.js
+++ b/bin/console.js
@@ -3,7 +3,7 @@
 /*
  * BIN console
  *
- * Author: Rafal Michalski (c) 2017-2018
+ * Author: Rafal Michalski (c) 2017-2020
  */
 
 const assert = require('assert');
@@ -35,6 +35,7 @@ const lookup = require('../lib/utils/dns_lookup').hostsToZmqUrls;
 const { genIdent } = require('../lib/utils/id');
 const { createRepl } = require('../lib/utils/repl');
 const ZmqRaftPeerClient = require('../lib/client/zmq_raft_peer_client');
+const ZmqRaftPeerSub = require('../lib/client/zmq_raft_peer_sub');
 const ZmqRaftClient = require('../lib/client/zmq_raft_client');
 const ZmqRaftSubscriber = require('../lib/client/zmq_raft_subscriber');
 const { LOG_ENTRY_TYPE_STATE, LOG_ENTRY_TYPE_CONFIG, LOG_ENTRY_TYPE_CHECKPOINT
@@ -121,6 +122,58 @@ readConfig(argv[0] || defaultConfig, "raft")
       }
     }
   });
+  repl.defineCommand('subp', {
+    help: 'Subscribe to a single broadcast state peer: [host[:port]|lastIndex]',
+    action: function(host) {
+      if (!host || /^\d+$/.test(host)) {
+        if (client && client.foreverEntriesStream) {
+          if (subs && !subs.destroyed) {
+            subs.destroy();
+          }
+          let lastIndex = parseInt(host);
+          if (!Number.isFinite(lastIndex)) {
+            lastIndex = config.console.subscriber.lastIndex;
+          }
+          subs = client.foreverEntriesStream(lastIndex);
+          repl.context.subs = subs;
+          subs.on('end', () => {
+            console.log(cyan("forever stream ends, peer is not a LEADER"))
+          });
+          subs.on('close', () => {
+            console.log(red("forever stream closed"));
+          });
+          subs.on('data', showSubStreamEntry);
+          subs.on('error', error);
+        }
+        else {
+          console.log(yellow("subscribe to a peer first"));
+        }
+        prompt(repl)
+      }
+      else {
+        lookup(host).then(urls => {
+          shutdownClients();
+          const opts = Object.assign({},
+            config.console.client,
+            config.console.subscriber,
+          {
+            secret: repl.context.secret,
+          });
+          client = new ZmqRaftPeerSub(urls, opts);
+          repl.context.client = client;
+          console.log('subscribing to peer: %s', urls[0]);
+          client.on('error', error);
+          client.on('pub', url => console.log("PUB url: %s", green(url)));
+          // client.on('pulse', (ix, term, entries) => {
+          //   console.log(red("(( ))") + grey(" index: %s, term: %s, entries: %s"), ix, term, entries.length);
+          // });
+          client.on('timeout', () => console.log(red("(X) BSM timeout!")));
+          client.on('close', () => console.log(grey("peer subscriber closed")));
+        })
+        .then(() => prompt(repl)).catch(error);
+      }
+    }
+  });
   repl.defineCommand('connect', {
     help: 'Connect a client to zmq-raft servers: host[:port] [host...]',
     action: function(hosts) {
@@ -153,30 +206,9 @@ readConfig(argv[0] || defaultConfig, "raft")
         subs = new ZmqRaftSubscriber(urls, opts);
         repl.context.client = subs.client;
         repl.context.subs = subs;
-        console.log('connecting to: %s', urls.join(', '));
+        console.log('subscribing to: %s', urls.join(', '));
         subs.on('error', error);
-        subs.on('data', entry => {
-          var logIndex = repl.context.entries.logIndex = entry.logIndex
-            , decode = repl.context.entries.decode;
-          if (entry.isLogEntry) {
-            switch(entry.entryType) {
-            case LOG_ENTRY_TYPE_STATE:
-              console.log('subscriber index: %s term: %s data: %j', logIndex, entry.readEntryTerm(), decode(entry.readEntryData()));
-              break;
-            case LOG_ENTRY_TYPE_CONFIG:
-              console.log('subscriber index: %s term: %s config', logIndex, entry.readEntryTerm());
-              break;
-            case LOG_ENTRY_TYPE_CHECKPOINT:
-              console.log('subscriber index: %s term: %s checkpoint', logIndex, entry.readEntryTerm());
-              break;
-            }
-          } else {
-            console.log('snapshot chunk offset: %s of %s (%s bytes)', entry.snapshotByteOffset, entry.snapshotTotalLength, entry.length);
-            if (entry.isLastChunk) {
-              console.log('snapshot done, logIndex %s logTerm %s', entry.logIndex, entry.logTerm);
-            }
-          }
-        });
+        subs.on('data', showSubStreamEntry);
       })
       .then(() => prompt(repl)).catch(error);
     }
@@ -195,7 +227,7 @@ readConfig(argv[0] || defaultConfig, "raft")
       const flood = repl.context.flood;
       if (data) flood.data = data;
       if (!flood.flooding) {
-        if (subs) startFloodingStream(repl, subs);
+        if (subs && subs.write) startFloodingStream(repl, subs);
         else if (client) startFloodingClient(repl, client);
         else console.log(yellow('not connected'));
       }
@@ -389,8 +421,8 @@ readConfig(argv[0] || defaultConfig, "raft")
   };
 
   function shutdownClients() {
-    subs && subs.close();
-    client && client.close();
+    if (subs && subs.close) subs.close();
+    if (client && client.close) client.close();
     repl.context.subs = subs = undefined;
     repl.context.client = client = undefined;
     repl.context.flood.flooding = false;
@@ -424,6 +456,28 @@ readConfig(argv[0] || defaultConfig, "raft")
     return replError(repl, err);
   }
 
+  function showSubStreamEntry(entry) {
+    var logIndex = repl.context.entries.logIndex = entry.logIndex
+      , decode = repl.context.entries.decode;
+    if (entry.isLogEntry) {
+      switch(entry.entryType) {
+      case LOG_ENTRY_TYPE_STATE:
+        console.log('subscriber index: %s term: %s data: %j', logIndex, entry.readEntryTerm(), decode(entry.readEntryData()));
+        break;
+      case LOG_ENTRY_TYPE_CONFIG:
+        console.log('subscriber index: %s term: %s config', logIndex, entry.readEntryTerm());
+        break;
+      case LOG_ENTRY_TYPE_CHECKPOINT:
+        console.log('subscriber index: %s term: %s checkpoint', logIndex, entry.readEntryTerm());
+        break;
+      }
+    } else {
+      console.log('snapshot chunk offset: %s of %s (%s bytes)', entry.snapshotByteOffset, entry.snapshotTotalLength, entry.length);
+      if (entry.isLastChunk) {
+        console.log('snapshot done, logIndex %s logTerm %s', entry.logIndex, entry.logTerm);
+      }
+    }
+  }
 })).catch(err => console.warn(err.stack));
 
 function floodingNextFactory(enc, flood) {

--- a/bin/zmq-monitor.js
+++ b/bin/zmq-monitor.js
@@ -17,6 +17,7 @@ program
   .version('1.0.0')
   .usage('[options] url...')
   .description('start zmq-monitor using provided options and url seeds')
+  .option('-p, --peers <ids...>', 'Assume given urls are peers with given IDs (no config query)')
   .option('-u, --urls-only', 'Monitor only given urls')
   .option('-k, --cluster <secret>', 'Secret cluster identity part of the protocol', '')
   .option('-i, --interval <secs>', 'How often peers should be queried (in seconds)')
@@ -37,6 +38,17 @@ const options = {
 
 if (program.urlsOnly) {
   options.urlsOnly = true;
+}
+
+if (program.peers) {
+  const ids = program.peers
+      , urls = options.urls;
+
+  if (ids.length !== urls.length) {
+    console.error("zmq-monitor: the number of given peer IDs should match the number of given URLs");
+    program.help();
+  }
+  options.peers = options.urls.map((url, i) => [ids[i], url]);
 }
 
 try {

--- a/bin/zmq-monitor.js
+++ b/bin/zmq-monitor.js
@@ -5,7 +5,7 @@ if (require.main !== module) throw new Error("zmq-monitor.js must be run directl
 
 const { format } = require('util');
 
-const { red, bgGreen } = require('colors/safe');
+const { red, bgGreen, grey } = require('colors/safe');
 
 const program = require('commander')
     , debug = require('debug')('zmq-monitor');
@@ -17,6 +17,7 @@ program
   .version('1.0.0')
   .usage('[options] url...')
   .description('start zmq-monitor using provided options and url seeds')
+  .option('-u, --urls-only', 'Monitor only given urls')
   .option('-k, --cluster <secret>', 'Secret cluster identity part of the protocol', '')
   .option('-i, --interval <secs>', 'How often peers should be queried (in seconds)')
   .option('-t, --timeout <secs>', 'How long to wait for a peer to respond (in seconds)')
@@ -33,6 +34,10 @@ const options = {
     secret: program.cluster,
     urls: program.args
 };
+
+if (program.urlsOnly) {
+  options.urlsOnly = true;
+}
 
 try {
   function validateSeconds(name, min) {
@@ -94,7 +99,7 @@ mon
 .on('close', () => debug('closed'))
 
 function fval(value, size, padder) {
-  value = (value == null) ? '?' : '' + value;
+  value = (value == null) ? '-' : '' + value;
   return lpad('' + value, size, padder);
 }
 
@@ -123,7 +128,10 @@ function printAll() {
   for(let {id, url, info} of peerInfo.values()) {
     let line = format('%s: %s %s',
                           fval(id, 10, ' '),
-                          info.err ? 'X' : (info.isLeader ? 'M' : 'F'),
+                          (info.err ? 'X'
+                                    : (info.isLeader ? 'M'
+                                                     : (info.isLeader == null ? '?'
+                                                                              : 'F'))),
                           fval(info.currentTerm, 8, ' '),
                           fval(info.commitIndex, 8, ' '),
                           fval(info.lastIndex, 8, ' '),
@@ -135,6 +143,9 @@ function printAll() {
     }
     else if (info.isLeader) {
       console.log(bgGreen(line));
+    }
+    else if (info.isLeader == null) {
+      console.log(grey(line));
     }
     else {
       console.log(line);

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -7,4 +7,5 @@ exports.ZmqBaseSocket = require('./zmq_base_socket');
 exports.ZmqProtocolSocket = require('./zmq_protocol_socket');
 exports.ZmqRaftPeerClient = require('./zmq_raft_peer_client');
 exports.ZmqRaftClient = require('./zmq_raft_client');
+exports.ZmqRaftPeerSub = require('./zmq_raft_peer_sub');
 exports.ZmqRaftSubscriber = require('./zmq_raft_subscriber');

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,9 +1,10 @@
 /* 
- *  Copyright (c) 2016 Rafał Michalski <royal@yeondir.com>
+ *  Copyright (c) 2016-2020 Rafał Michalski <royal@yeondir.com>
  */
 "use strict";
 
 exports.ZmqBaseSocket = require('./zmq_base_socket');
 exports.ZmqProtocolSocket = require('./zmq_protocol_socket');
+exports.ZmqRaftPeerClient = require('./zmq_raft_peer_client');
 exports.ZmqRaftClient = require('./zmq_raft_client');
 exports.ZmqRaftSubscriber = require('./zmq_raft_subscriber');

--- a/lib/client/zmq_protocol_socket.js
+++ b/lib/client/zmq_protocol_socket.js
@@ -21,22 +21,22 @@
 
   example:
 
-  sock = new ZmqProtocolSocket('tcp://127.0.0.1:1234', options);
-  sock.request(['foo'], (args, reply, refresh) => {
-    console.log('received response');
-    if (args.length !== 1) throw new Error("invalid response!");
-    if (args[0].equals(done)) {
-      reply('send more');
-      refresh();
-    }
-    else {
-     return args;
-    }
-  }, {timeout: xxx, id: 'deadbaca'});
-  // handle response
-  .then(resp => console.log(resp))
-  // handle timeout or close error
-  .catch(err => console.error(err));
+    sock = new ZmqProtocolSocket('tcp://127.0.0.1:1234', options);
+    sock.request(['foo'], (args, reply, refresh) => {
+      console.log('received response');
+      if (args.length !== 1) throw new Error("invalid response!");
+      if (args[0].equals(done)) {
+        reply('send more');
+        refresh();
+      }
+      else {
+       return args;
+      }
+    }, {timeout: xxx, id: 'deadbaca'});
+    // handle response
+    .then(resp => console.log(resp))
+    // handle timeout or close error
+    .catch(err => console.error(err));
 */
 
 const isArray = Array.isArray;
@@ -90,7 +90,7 @@ class ZmqProtocolSocket extends ZmqBaseSocket {
    *
    * `options` may be one of:
    *
-   * - `urls` {string}: urls of the servers to connect to
+   * - `urls` {string|Array}: urls of the servers to connect to
    * - `timeout` {number}: default timeout in milliseconds
    * - `lazy` {boolean}: specify `true` to connect lazily on first request
    * - `sockopts` {Object}: specify zmq socket options as object e.g.: {ZMQ_IPV4ONLY: true}

--- a/lib/client/zmq_protocol_socket.js
+++ b/lib/client/zmq_protocol_socket.js
@@ -1,42 +1,44 @@
 /* 
- *  Copyright (c) 2016 Rafał Michalski <royal@yeondir.com>
+ *  Copyright (c) 2016-2020 Rafał Michalski <royal@yeondir.com>
  */
 "use strict";
 
 /*
-  ZmqProtocolSocket is a handy wrapper for zmq DEALER socket that implements RPC pattern.
+  ZmqProtocolSocket is a handy wrapper for zeromq DEALER socket that implements RPC pattern.
 
   The requests are handled with promises.
 
   ZmqProtocolSocket allows user to set timeout for every request. Result promise will be rejected
-  with TimeoutError in this instance.
+  with TimeoutError on response timeout.
 
-  ZmqProtocolSocket guarantees that responses will be correlated with requests.
+  ZmqProtocolSocket makes best effort that responses will be correlated with requests.
   ZmqProtocolSocket DOES NOT guarantee that the order of responses will be the same as the order of requests.
 
-  Requests may receive many responses and send additional messages in reply to them (for streaming).
-  The special `onresponse` callback is provided for this purpose.
+  Streaming can be realized by multi-reply and multi-request RPCs.
+  See the `onresponse` option of the ZmqProtocolSocket.prototype.request method.
 
-  When request promise is being resolved or rejected any late responses are discarded.
+  When request promise is being resolved or rejected any stale responses are being discarded.
 
-  example:
+  Example:
 
-    sock = new ZmqProtocolSocket('tcp://127.0.0.1:1234', options);
-    sock.request(['foo'], (args, reply, refresh) => {
-      console.log('received response');
-      if (args.length !== 1) throw new Error("invalid response!");
-      if (args[0].equals(done)) {
-        reply('send more');
-        refresh();
-      }
-      else {
-       return args;
-      }
-    }, {timeout: xxx, id: 'deadbaca'});
-    // handle response
-    .then(resp => console.log(resp))
-    // handle timeout or close error
-    .catch(err => console.error(err));
+    let sock = new ZmqProtocolSocket('tcp://127.0.0.1:1234', {timeout: 500});
+
+    # simple request
+    let response = await sock.request(['foo']);
+
+    # streaming request
+    let response = await sock.request(['bar'], {
+      onresponse: (resp, reply, refresh) => {
+        console.log('received response');
+        if (resp.length !== 1) throw new Error("invalid response!");
+        if (resp[0].equals(processing)) {
+          reply('ok waiting');
+          refresh();
+        }
+        else {
+         return resp;
+        }
+      });
 */
 
 const isArray = Array.isArray;
@@ -88,21 +90,21 @@ class ZmqProtocolSocket extends ZmqBaseSocket {
   /**
    * Create ZmqProtocolSocket
    *
-   * `options` may be one of:
+   * `options`:
    *
-   * - `urls` {string|Array}: urls of the servers to connect to
-   * - `timeout` {number}: default timeout in milliseconds
-   * - `lazy` {boolean}: specify `true` to connect lazily on first request
-   * - `sockopts` {Object}: specify zmq socket options as object e.g.: {ZMQ_IPV4ONLY: true}
-   * - `protocol` {Object}: default frames protocol
-   * - `highwatermark` {number}: shortcut to specify ZMQ_SNDHWM for a zmq DEALER socket
-   *   this affects how many messages are queued per server so if one of the peers
-   *   goes down this many messages are possibly lost
-   *   (unless the server goes up and responds within the request timeout)
-   *   default is 2
-   *                 
+   * - `urls` {string|Array<string>}: An url or urls of the servers to connect to.
+   * - `timeout` {int32}: Default response timeout in milliseconds; 0, negative or not specified
+   *                      disables default timeout.
+   * - `lazy` {boolean}: Specify `true` to connect lazily on the first request.
+   * - `sockopts` {Object}: Specify zeromq socket options as an object e.g.: {ZMQ_IPV4ONLY: true}.
+   * - `protocol` {FramesProtocol}: The default frames protocol; by default the raw frames are passed.
+   * - `highwatermark` {number}: A shortcut to specify `ZMQ_SNDHWM` socket option for an underlying
+   *                   zeromq DEALER socket; this affects how many messages are queued per server
+   *                   so if one of the peers goes down this many messages are possibly lost;
+   *                   setting it prevents spamming a peer with expired messages when temporary
+   *                   network partition occures (default: 2).
    *
-   * @param {string|Array} [urls] - this overrides urls set in options
+   * @param {string|Array} [urls] - overrides urls set in options.
    * @param {number|Object} options or default timeout
    * @return {ZmqProtocolSocket}
   **/
@@ -126,21 +128,35 @@ class ZmqProtocolSocket extends ZmqBaseSocket {
   }
 
   /**
-   * Send request
-   * `options` may be one of:
+   * Send an RPC request.
    *
-   * - `id` {string|Buffer}: custom request id
-   * - `timeout` {number}: timeout in milliseconds
-   * - `protocol` {Object}: frames protocol
-   * - `onresponse` {Function}: callback for handling multiple replies
-   *    signature: (msgs, reply, refresh) => result
-   *    reply({Array}) allows to send additional requests
-   *    refresh([{number}]) allows to refresh timeout
-   *    result !== undefined will end request and resolve request promise
+   * `options`:
    *
-   * @param {string|Array} msg
+   * - `id` {string|Buffer}: A custom request ID, if not specified a unique int32 request ID
+   *                         will be generated.
+   * - `timeout` {int32}: A request timeout override in milliseconds;
+   *                      if 0 or unspecified uses default timeout;
+   *                      negative values disable the timeout completely.
+   * - `protocol` {FramesProtocol}: Frames protocol used for the RPC.
+   * - `onresponse` {Function}: A callback for handling multi-reply RPCs.
+   *
+   * The `onresponse` function signature is:
+   *    (
+   *      responseMessage: Array,
+   *      reply: (msg: Array|string|Buffer) => void,
+   *      refresh: (int32|undefined) => void
+   *    ) => undefined|any
+   *
+   * - `reply` can be used to send additional requests.
+   * - `refresh` can be used to restart timeout counter, optionally overriding the `timeout` interval.
+   *
+   * If `onresponse` returns something other than `undefined`, the RPC will be finished and the RPC
+   * promise resolves to the returned value. Returning `undefined` indicates that more responses
+   * are to be expected.
+   *
+   * @param {string|Array} msg - a request message to send.
    * @param {Object} [options]
-   * @return {Promise}
+   * @return {Promise} resolves to the RPC result.
   **/
   request(msg, options) {
     options || (options = {});
@@ -202,7 +218,7 @@ class ZmqProtocolSocket extends ZmqBaseSocket {
   }
 
   /**
-   * Disconnect, close socket and reject all pending requests
+   * Disconnect, close socket and reject all pending requests.
    *
    * @return {ZmqProtocolSocket}
   **/
@@ -230,7 +246,10 @@ class ZmqProtocolSocket extends ZmqBaseSocket {
   }
 
   /**
-   * Connect socket
+   * Connect socket.
+   *
+   * This method is implicitly called by ZmqProtocolSocket.prototype.request method
+   * if an instance of ZmqProtocolSocket was initialized lazily.
    *
    * @return {ZmqProtocolSocket}
   **/
@@ -312,11 +331,12 @@ class ZmqProtocolSocket extends ZmqBaseSocket {
   }
 
   /**
-   * Wait for all queues to drain
+   * Wait for all queues to drain.
    *
-   * call before close() or destroy() to make sure all data has been flushed
+   * Call before close() or destroy() to make sure all outbound data has been flushed.
+   * The returned promise resolves when data has been flushed or is rejected on timeout.
    *
-   * @param {number} timeout
+   * @param {number} timeout - how long to wait in milliseconds.
    * @return {Promise}
   **/
   waitForQueues(timeout) {

--- a/lib/client/zmq_raft_client.js
+++ b/lib/client/zmq_raft_client.js
@@ -8,42 +8,17 @@ const isArray = Array.isArray
 
 const assert = require('assert');
 
-// const { Readable } = require('stream');
-
 const { encode: encodeMsgPack } = require('msgpack-lite');
 
 const { assertConstantsDefined, parsePeers } = require('../utils/helpers');
-// const { bufferToLogEntry } = require('../common/log_entry');
-// const { bufferToSnapshotChunk } = require('../common/snapshot_chunk');
 
 /* expect response within this timeout, if not will try the next server */
 const { SERVER_ELECTION_GRACE_DELAY
-
-      // , RE_STATUS_NOT_LEADER
-      // , RE_STATUS_LAST
-      // , RE_STATUS_MORE
-      // , RE_STATUS_SNAPSHOT
-
-      // , REQUEST_ENTRIES
       } = require('../common/constants');
 
 assertConstantsDefined({
   SERVER_ELECTION_GRACE_DELAY
-// , RE_STATUS_NOT_LEADER
-// , RE_STATUS_LAST
-// , RE_STATUS_MORE
-// , RE_STATUS_SNAPSHOT
 }, 'number');
-
-assertConstantsDefined({
- // REQUEST_ENTRIES
-}, 'string', true);
-
-// const requestEntriesTypeBuf = Buffer.from(REQUEST_ENTRIES);
-
-// const { createFramesProtocol } = require('../protocol');
-
-// const requestEntriesProtocol = createFramesProtocol('RequestEntries');
 
 const ZmqRaftPeerClient = require('../client/zmq_raft_peer_client');
 const TimeoutError = ZmqRaftPeerClient.TimeoutError;
@@ -53,51 +28,44 @@ const rcPending$ = Symbol('rcPending');
 
 const debug = require('debug')('zmq-raft:client');
 
-// function OutOfOrderError(message) {
-//   Error.captureStackTrace(this, OutOfOrderError);
-//   this.name = 'OutOfOrderError';
-//   this.message = message || 'chunks received out of order';
-// }
-
-// OutOfOrderError.prototype = Object.create(Error.prototype);
-// OutOfOrderError.prototype.constructor = OutOfOrderError;
-// OutOfOrderError.prototype.isOutOfOrder = true;
-
 /**
- * This client executes RPC calls on the 0MQ Raft cluster.
+ * This client can be used to execute the 0MQ Raft RPC protocol on the cluster of peers.
  * 
- * Overrides the ZmqRaftPeerClient RPC methods making them resilient to singular peer failures.
+ * Overrides the ZmqRaftPeerClient RPC methods making them resilient to peer failures.
  * 
- * The `timeout` argument of all the RPC methods also changes meaning.
- * When the peer ZmqRaftPeerClient methods would just throw a timeout error waiting for the
- * single response, the RPC methods of ZmqRaftClient would repeat requests, to every known peer
- * in the cluster.
+ * The meaning of the `rpctimeout` argument of the overridden RPC methods should be understood
+ * as follows. Promises returned from ZmqRaftPeerClient methods would reject with a timeout error
+ * while waiting for a single response from the peer, whereas the RPC methods of ZmqRaftClient
+ * will repeat the request to every known peer in the cluster in this instance.
+ * The `rpctimeout` argument given to these RPC methods is an expiration timeout put on top of
+ * the whole RPC process. The TimeoutError will be thrown possibly after several attempts to
+ * contact several different peers.
  * 
- * The `timeout` argument given to these RPC methods is an expiration timeout put on top
- * of the whole procedure. The timeout error will be thrown after possible several attemps
- * to contact several different cluster peers.
+ * To control the peer response timeout, after which the request will be reattempted to the next
+ * peer in the cluster, use the `timeout` option while initializing a new instance of ZmqRaftClient.
  * 
- * Also these RPC methods never throw PeerNotLeaderError. Instead they retry sending requests
- * to the new leader. When the election is still pending a client gives a little time (grace delay)
- * for the cluster to elect the new leader.
+ * RPC methods of ZmqRaftClient never throw PeerNotLeaderError. Instead, they retry sending
+ * requests to the new leader. When the election is still pending, a client gives a little time
+ * (`serverElectionGraceDelay`) for the cluster to elect the new leader before reattempting the
+ * pending request.
 **/
 class ZmqRaftClient extends ZmqRaftPeerClient {
   /**
    * Create an instance of ZmqRaftClient.
-   *
+   * 
    * `options` may be one of:
-   *
+   * 
    * - `url` {string}: A seed url to fetch peer urls from via a Request Config RPC.
    * - `urls` {Array<string>}: An array of seed urls to fetch peers from via a Request Config RPC.
    * - `peers` {Array}: An array of established zmq raft server descriptors;
-   *                    `peers` has precedence over `urls` and if provided the peer list
-   *                    is not being fetched via Request Config RPC.
+   *                    this option has precedence over `urls`, and if provided, the peer list
+   *                    is not being initially fetched via Request Config RPC.
    * - `secret` {string|Buffer}: A cluster identifying string which is sent and verified against
    *                             in each message.
-   * - `timeout` {number}: A time interval in milliseconds after which we consider a server peer as unresponsive.
-   *                       The request will be repeated if waiting for the response exceeds this interval.
-   *                       In this case the next request will be send to the new leader or the next
-   *                       peer in the cluster if the leader is not known.
+   * - `timeout` {int32}: A time interval in milliseconds after which we consider a server peer
+   *                      to be unresponsive; the request will be reattempted if waiting for the
+   *                      response  exceeds this interval; in this instance the next request 
+   *                      attempt will be send to the next peer in the cluster.
    * - `serverElectionGraceDelay` {number}: A delay in milliseconds to wait for the cluster
    *                                        leader to elect before re-trying (default: 300).
    * - `lazy` {boolean}: Specify `true` to connect lazily on the first request.
@@ -110,7 +78,7 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
    *                   so if one of the peers goes down this many messages are possibly lost;
    *                   setting it prevents spamming a peer with expired messages when temporary
    *                   network partition occures (default: 2).
-   *
+   * 
    * @param {string|Array<string>} [urls]
    * @param {Object} [options]
    * @return {ZmqRaftClient}
@@ -158,7 +126,7 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Disconnect, close socket and reject all pending requests.
-   *
+   * 
    * @return {ZmqRaftClient}
   **/
   close() {
@@ -179,11 +147,11 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Set the new leader.
-   *
+   * 
    * If the given `leaderId` is found in the cluster configuration only one connection to the
    * leader's url will be sustained. Otherwise the client will connect to all the known peers
    * in the cluster.
-   *
+   * 
    * @param {string|null} [leaderId] - the known leader ID or null.
    * @param {boolean} [forceSetUrls] - forces re-checking connections regardless if leader ID
    *                                   has changed or not.
@@ -215,13 +183,13 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
   }
 
   /**
-   * Set the new cluster config.
-   *
-   * This call will update the last known cluster config and establish the connection
+   * Set the new cluster configuration.
+   * 
+   * This call will update the last known cluster configuration and establish the connection
    * according to the given `leaderId` argument.
-   *
+   * 
    * See ZmqRaftClient.prototype.setLeader for details on how the connections are set up.
-   *
+   * 
    * @param {Array} [peers]
    * @param {string} [leaderId]
    * @return {this}
@@ -235,27 +203,31 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Invoke RequestConfig RPC.
-   *
+   * 
    * The returned promise resolves to an Object with the following properties on success:
-   * - `leaderId` {string|null}
-   * - `isLeader` {boolean}
-   * - `peers` {Array<[id, url]>}
+   * - `leaderId` {string} - ID of the current LEADER and the responding peer.
+   * - `isLeader` {boolean} - indicates the LEADER state of the responding peer, always `true`.
+   * - `peers` {Array<[id, url]>} - the current cluster configuration.
    * - `urls`: {{id: url}} - same as `peers`, but provided as an Object map for convenience.
-   *
-   * The response will be accepted only from the current leader.
-   *
+   * 
+   * The response will be authoritative - is accepted only from the current leader.
+   * 
    * On success this method will update the last known cluster configuration.
-   *
-   * @param {number} [timeout] - an interval in milliseconds, after which the request is
-   *                             abandoned and the returned promise resolves with `undefined`.
+   * 
+   * If `rpctimeout` argument is 0, null or undefined, the request will be reattempted indefinitely.
+   * 
+   * The promise will be rejected with TimeoutError only when both conditions are met:
+   * - Waiting for the response from the last peer takes longer than the `timeout` option given to
+   *   the constructor, and
+   * - the request has expired.
+   * 
+   * @param {int32} [rpctimeout] - the time, in milliseconds, until the request expires.
    * @return {Promise}
-   *
-   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
-  requestConfig(timeout) {
+  requestConfig(rpctimeout) {
     var expire;
-    timeout |= 0;
-    if (timeout !== 0) expire = now() + timeout;
+    rpctimeout |= 0;
+    if (rpctimeout !== 0) expire = now() + rpctimeout;
 
     const request = () => {
       return super.requestConfig()
@@ -267,12 +239,12 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
             /* clear pending on request forever only */
             this[rcPending$] = undefined;
           }
-          var urls = {};
+          let urls = {};
           peers.forEach(([id, url]) => { urls[id] = url; });
           return {leaderId, isLeader, peers, urls};
         }
         else {
-          /* expire now if must */
+          /* expire now? */
           if (expire !== undefined && now() >= expire)
             throw new TimeoutError();
           /* not a leader */
@@ -282,7 +254,7 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
       })
       .catch(err => {
         if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured re-trying config request with another server');
+          debug('response timeout: reattempting config request with another peer');
           this.setLeader(null);
           return request();
         }
@@ -307,9 +279,9 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Invoke RequestLogInfo RPC.
-   *
+   * 
    * The returned promise resolves to an Object with the following properties:
-   *
+   * 
    *  - isLeader {boolean}
    *  - leaderId {string|null}
    *  - currentTerm {number}
@@ -319,23 +291,24 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
    *  - lastIndex {number}
    *  - snapshotSize {number}
    *  - pruneIndex {number}
-   *
-   *
+   * 
+   * The promise will be rejected with TimeoutError only when both conditions are met:
+   * - Waiting for the response from the last peer takes longer than the `timeout` option given to
+   *   the constructor, and
+   * - the request has expired.
+   * 
    * @param {boolean} anyPeer - whether a response from any peer will be accepted.
-   * @param {number} [timeout] - an interval in milliseconds, after which the request is
-   *                             abandoned and the returned promise resolves with `undefined`.
+   * @param {int32} [rpctimeout] - the time, in milliseconds, until the request expires.
    * @return {Promise}
-   *
-   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
-  requestLogInfo(anyPeer, timeout) {
+  requestLogInfo(anyPeer, rpctimeout) {
     if (this.peers.size === 0) {
-      return this.requestConfig(timeout).then(() => this.requestLogInfo(anyPeer, timeout));
+      return this.requestConfig(rpctimeout).then(() => this.requestLogInfo(anyPeer, rpctimeout));
     }
 
     var expire;
-    timeout |= 0;
-    if (timeout !== 0) expire = now() + timeout;
+    rpctimeout |= 0;
+    if (rpctimeout !== 0) expire = now() + rpctimeout;
 
     const request = () => {
       return super.requestLogInfo()
@@ -348,7 +321,8 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
               throw new TimeoutError();
             /* not a leader, re-try */
             return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
-                                            .then(() => this.requestConfig(timeout)).then(request)
+                                            .then(() => this.requestConfig(rpctimeout))
+                                            .then(request)
                                           : request();
           }
         }
@@ -357,7 +331,7 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
       })
       .catch(err => {
         if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured re-trying log info request with another server');
+          debug('response timeout: reattempting log info request with another peer');
           this.setLeader(null);
           return request();
         }
@@ -370,28 +344,30 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Invoke ConfigUpdate RPC.
-   *
+   * 
    * The returned promise resolves to the log index of the committed entry of Cold,new on success.
-   *
+   * 
    * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
    * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
    * `id` should be freshly generated. Its "the seconds" part is important
    * because update requests might expire after `common.constants.DEFAULT_REQUEST_ID_TTL`
    * milliseconds.
-   *
+   * 
    * You may use `utils.id.genIdent()` function to generate them.
-   *
+   * 
+   * The promise will be rejected with TimeoutError only when both conditions are met:
+   * - Waiting for the response from the last peer takes longer than the `timeout` option given to
+   *   the constructor, and
+   * - the request has expired.
+   * 
    * @param {string|Buffer} id - a request ID to ensure idempotent updates.
    * @param {Array} peers - the new cluster configuration.
-   * @param {number} [timeout] - an interval in milliseconds, after which the request is
-   *                             abandoned and the returned promise is rejected with TimeoutError.
+   * @param {int32} [rpctimeout] - the time, in milliseconds, until the request expires.
    * @return {Promise}
-   *
-   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
-  configUpdate(id, peers, timeout) {
+  configUpdate(id, peers, rpctimeout) {
     if (this.peers.size === 0) {
-      return this.requestConfig(timeout).then(() => this.configUpdate(id, peers, timeout));
+      return this.requestConfig(rpctimeout).then(() => this.configUpdate(id, peers, rpctimeout));
     }
 
     try {
@@ -399,8 +375,8 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
     } catch(err) { return Promise.reject(err); }
 
     var expire;
-    timeout |= 0;
-    if (timeout !== 0) expire = now() + timeout;
+    rpctimeout |= 0;
+    if (rpctimeout !== 0) expire = now() + rpctimeout;
 
     const request = () => {
       return super.configUpdate(id, peers)
@@ -413,11 +389,12 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
             throw new TimeoutError();
           /* continue */
           return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
-                                          .then(() => this.requestConfig(timeout)).then(request)
-                                        : request();          
+                                          .then(() => this.requestConfig(rpctimeout))
+                                          .then(request)
+                                        : request();
         }
         else if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured re-trying config update request with another server');
+          debug('response timeout: reattempting update config request with another peer');
           this.setLeader(null);
           return request();
         }
@@ -430,32 +407,34 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Invoke RequestUpdate RPC.
-   *
+   * 
    * The returned promise resolves to the log index of the committed entry.
-   *
+   * 
    * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
    * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
    * `id` should be freshly generated. Its "the seconds" part is important
    * because update requests might expire after `common.constants.DEFAULT_REQUEST_ID_TTL`
    * milliseconds.
-   *
+   * 
    * You may use `utils.id.genIdent()` function to generate them.
-   *
+   * 
+   * The promise will be rejected with TimeoutError only when both conditions are met:
+   * - Waiting for the response from the last peer takes longer than the `timeout` option given to
+   *   the constructor, and
+   * - the request has expired.
+   * 
    * @param {string|Buffer} id - a request ID to ensure idempotent updates.
    * @param {Buffer} data - log entry data to modify the state.
-   * @param {number} [timeout] - an interval in milliseconds, after which the request is
-   *                             abandoned and the returned promise is rejected with TimeoutError.
+   * @param {int32} [rpctimeout] - the time, in milliseconds, until the request expires.
    * @return {Promise}
-   *
-   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
-  requestUpdate(id, data, timeout) {
+  requestUpdate(id, data, rpctimeout) {
     if (this.peers.size === 0) {
-      return this.requestConfig(timeout).then(() => this.requestUpdate(id, data, timeout));
+      return this.requestConfig(rpctimeout).then(() => this.requestUpdate(id, data, rpctimeout));
     }
     var expire;
-    timeout |= 0;
-    if (timeout !== 0) expire = now() + timeout;
+    rpctimeout |= 0;
+    if (rpctimeout !== 0) expire = now() + rpctimeout;
     const request = () => {
       return super.requestUpdate(id, data)
       .catch(err => {
@@ -467,11 +446,11 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
             throw new TimeoutError();
           /* continue */
           return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
-                                          .then(() => this.requestConfig(timeout)).then(request)
+                                          .then(() => this.requestConfig(rpctimeout)).then(request)
                                         : request();
         }
         else if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured re-trying log update request with another server');
+          debug('response timeout: reattempting update state request with another peer');
           this.setLeader(null);
           return request();
         }
@@ -484,63 +463,62 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
   /**
    * Perform RequestEntries RPC.
-   *
-   * Retrieve entries using the `receiver` callback.
-   *
+   * 
+   * Retrieve RAFT log entries using the `receiver` callback.
+   * 
    * The received entries must be consumed ASAP and the retrieving of them can not be paused.
    * However it is possible to cancel the request while processing entries.
-   *
+   * 
    * Use ZmqRaftClient.prototype.requestEntriesStream to work with the back-pressured streams instead.
-   *
+   * 
    * The returned promise will resolve to `true` if all of the requested entries were received.
    * Otherwise the promise will resolve to `false` if the request was canceled by the receiver.
-   *
+   * 
    * The `receiver` function may modify its entries array argument (e.g. clear it).
    * The `receiver` may request to stop receiving entries if the function returns `false`
    * (that is an exact boolean `false`, not a falsy-ish value).
-   *
+   * 
    * The `receiver` function signature:
    *   (status: number, entries_or_snapshot_chunk: Array|Buffer, lastIndex: number,
    *    byteOffset?: number, snapshotSize?: number, isLastChunk?: boolean, snapshotTerm?: number
    *   ) => false|any
-   *
+   * 
    * The `status` in this case may be one of:
-   *
+   * 
    * - 1: this is the last batch.
    * - 2: expect more entries.
    * - 3: this is a snapshot chunk.
-   *
+   * 
+   * The promise will be rejected with TimeoutError only when both conditions are met:
+   * - Waiting for the last response from the server takes longer than the `timeout` option given to
+   *   the constructor, and
+   * - the request has expired.
+   * 
    * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
    *                             (e.g. the index of the last received entry), specify 0 to start from 1.
    * @param {number} [count] - the maximum number of requested entries, only valid if > 0; otherwise ignored.
    * @param {Function} receiver - the function to process received entries.
-   * @param {number} [timeout] - an interval in milliseconds, after which the request is considered as
-   *                             expired and the returned promise may be rejected with TimeoutError.
+   * @param {int32} [rpctimeout] - the time, in milliseconds, until the request expires.
    * @param {number} [snapshotOffset] - a hint for the server to start responding with snapshot chunks
-   *           starting from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
+   *        starting from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
    * @return {Promise}
-   *
-   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
-   *
-   * The expiration timeout is checked agains only if the server does not respond within the RPC
-   * timeout interval, specified when the client was instantiated.
   **/
-  requestEntries(lastIndex, count, receiver, timeout, snapshotOffset) {
+  requestEntries(lastIndex, count, receiver, rpctimeout, snapshotOffset) {
     if (this.peers.size === 0) {
-      return this.requestConfig(timeout)
-                 .then(() => this.requestEntries(lastIndex, count, receiver, timeout));
+      return this.requestConfig(rpctimeout)
+                 .then(() => this.requestEntries(lastIndex, count, receiver, rpctimeout));
     }
     if ('function' === typeof count) {
-      snapshotOffset = timeout, timeout = receiver, receiver = count, count = undefined;
+      snapshotOffset = rpctimeout, rpctimeout = receiver, receiver = count, count = undefined;
     }
 
     var expire
-      , timeoutRPC = this.timeoutMs;
-    timeout |= 0;
-    if (timeout !== 0) expire = now() + timeout;
-    const maxTimeoutRPC = timeoutRPC * 5
+      , peerTimeout = this.timeoutMs;
+    rpctimeout |= 0;
+    if (rpctimeout !== 0) expire = now() + rpctimeout;
+    const maxPeerTimeout = peerTimeout * 5
         , request = () => {
-      return super.requestEntries(lastIndex, count, receiver, timeoutRPC, snapshotOffset)
+      return super.requestEntries(lastIndex, count, receiver, peerTimeout, snapshotOffset)
       .catch(err => {
         var state = err.requestEntriesState;
         lastIndex      = state.lastIndex;
@@ -555,17 +533,17 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
             throw new TimeoutError();
           /* continue */
           if (this.leaderId === null) { /* election in progress */
-            timeoutRPC = this.timeoutMs; /* reset timeout */
+            peerTimeout = this.timeoutMs; /* reset timeout */
             return this.delay(this.serverElectionGraceDelay)
-                  .then(() => this.requestConfig(timeout)).then(request);
+                  .then(() => this.requestConfig(rpctimeout)).then(request);
           }
           else return request();
         }
         else if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured re-trying entries request with another server');
+          debug('response timeout: reattempting log entries request with another peer');
           this.setLeader(null);
-          /* increase timeout, to prevent streaming timeout loop */
-          if ((timeoutRPC += this.timeoutMs) > maxTimeoutRPC) timeoutRPC = maxTimeoutRPC;
+          /* increase peer timeout, to prevent streaming peer timeout loop */
+          if ((peerTimeout += this.timeoutMs) > maxPeerTimeout) peerTimeout = maxPeerTimeout;
           return request();
         }
         else throw err;
@@ -576,31 +554,41 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
   }
 
   /**
-   * Returns a Readable stream that retrieves entries via the RequestEntries RPC.
-   *
+   * Returns a Readable stream that retrieves RAFT log entries via the RequestEntries RPC.
+   * 
    * The returned stream is lazy: RequestEntries RPC messages are sent to the cluster only when
    * data is requested via stream.Readable api.
-   *
+   * 
    * The returned stream can be back-pressured.
-   *
+   * 
    * The stream yields objects that are instances of either common.LogEntry or common.SnapshotChunk.
+   * 
+   * The stream will emit the "error" event with the TimeoutError only when both conditions are met:
+   * - Waiting for the last response from the server takes longer than the `timeout` option given to
+   *   the constructor, and
+   * - the request has expired.
    *
    * `options`:
-   *
+   * 
    * - `count` {number} - the maximum number of requested entries, only valid if > 0; otherwise ignored.
-   * - `timeout` {number} - an interval in milliseconds, after which the request is considered as
-   *                        expired and the "error" event may be emitted with the TimeoutError argument.
+   * - `rpctimeout` {int32} - the time, in milliseconds, until the request expires.
    * - `snapshotOffset` {number} - a hint for the server to start responding with snapshot chunks starting
    *                  from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
-   *
+   * 
    * Any other option is passed to the Readable constructor.
-   *
+   * 
    * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
    *                             (e.g. the index of the last received entry), specify 0 to start from 1.
-   * @param {number|Object} [count|options]
+   * @param {Object|number} [options|count]
    * @return {RequestEntriesStream}
   **/
   requestEntriesStream(lastIndex, options) {
+    if ('number' !== typeof options) {
+      options = Object.assign({}, options);
+      if (options.rpctimeout !== undefined) {
+        options.timeout = options.rpctimeout;
+      }
+    }
     return new RequestEntriesStream(this, lastIndex, options);
   }
 

--- a/lib/client/zmq_raft_client.js
+++ b/lib/client/zmq_raft_client.js
@@ -50,7 +50,6 @@ const TimeoutError = ZmqRaftPeerClient.TimeoutError;
 const RequestEntriesStream = ZmqRaftPeerClient.RequestEntriesStream;
 
 const rcPending$ = Symbol('rcPending');
-const timeout$   = Symbol('timeout');
 
 const debug = require('debug')('zmq-raft:client');
 
@@ -139,7 +138,6 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
 
     this.peers = peers;
     this.leaderId = null;
-    this[timeout$] = new Set();
     this.serverElectionGraceDelay = (options.serverElectionGraceDelay|0) || SERVER_ELECTION_GRACE_DELAY;
     this.heartbeatMs = options.heartbeat|0;
     if (this.heartbeatMs > 0) {
@@ -166,38 +164,8 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
   close() {
     clearTimeout(this.heartbeat);
     this.heartbeat = undefined;
-    for(let cancel of this[timeout$]) cancel(new Error("closed"));
-    assert(this[timeout$].size === 0);
     return super.close();
   }
-
-  /**
-   * Create a cancellable time delay promise.
-   *
-   * The promise will resolve to the given `result` after the `ms` milliseconds.
-   * If the client would be closed before the promise is resolved, the promise
-   * will be rejected immediately with an Error.
-   *
-   * @param {number} ms - delay interval in milliseconds.
-   * @param {any} [result] - the resolve argument.
-   * @return {Promise}
-  **/
-  delay(ms, result) {
-    var ts = this[timeout$];
-    return new Promise((resolve, reject) => {
-      var cancel = (err) => {
-        clearTimeout(timeout);
-        ts.delete(cancel);
-        reject(err);
-      },
-      timeout = setTimeout(() => {
-        ts.delete(cancel);
-        resolve(result)
-      }, ms);
-      ts.add(cancel);
-    });
-  };
-
 
   /**
    * The last known cluster config.

--- a/lib/client/zmq_raft_client.js
+++ b/lib/client/zmq_raft_client.js
@@ -268,7 +268,11 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
   /**
    * Invoke RequestConfig RPC.
    *
-   * Resolves to {leaderId: string|null, urls: {id: url}} on success.
+   * The returned promise resolves to an Object with the following properties on success:
+   * - `leaderId` {string|null}
+   * - `isLeader` {boolean}
+   * - `peers` {Array<[id, url]>}
+   * - `urls`: {{id: url}} - same as `peers`, but provided as an Object map for convenience.
    *
    * The response will be accepted only from the current leader.
    *
@@ -296,8 +300,8 @@ class ZmqRaftClient extends ZmqRaftPeerClient {
             this[rcPending$] = undefined;
           }
           var urls = {};
-          peers.forEach(([id, url]) => (urls[id] = url));
-          return {leaderId, urls};
+          peers.forEach(([id, url]) => { urls[id] = url; });
+          return {leaderId, isLeader, peers, urls};
         }
         else {
           /* expire now if must */

--- a/lib/client/zmq_raft_client.js
+++ b/lib/client/zmq_raft_client.js
@@ -1,5 +1,5 @@
 /* 
- *  Copyright (c) 2016-2017 Rafał Michalski <royal@yeondir.com>
+ *  Copyright (c) 2016-2020 Rafał Michalski <royal@yeondir.com>
  */
 "use strict";
 
@@ -8,97 +8,99 @@ const isArray = Array.isArray
 
 const assert = require('assert');
 
-const { Readable } = require('stream');
+// const { Readable } = require('stream');
 
 const { encode: encodeMsgPack } = require('msgpack-lite');
 
 const { assertConstantsDefined, parsePeers } = require('../utils/helpers');
-const { bufferToLogEntry } = require('../common/log_entry');
-const { bufferToSnapshotChunk } = require('../common/snapshot_chunk');
+// const { bufferToLogEntry } = require('../common/log_entry');
+// const { bufferToSnapshotChunk } = require('../common/snapshot_chunk');
 
 /* expect response within this timeout, if not will try the next server */
-const { SERVER_RESPONSE_TIMEOUT
-      , SERVER_ELECTION_GRACE_DELAY
+const { SERVER_ELECTION_GRACE_DELAY
 
-      , RE_STATUS_NOT_LEADER
-      , RE_STATUS_LAST
-      , RE_STATUS_MORE
-      , RE_STATUS_SNAPSHOT
+      // , RE_STATUS_NOT_LEADER
+      // , RE_STATUS_LAST
+      // , RE_STATUS_MORE
+      // , RE_STATUS_SNAPSHOT
 
-      , REQUEST_CONFIG
-      , REQUEST_UPDATE
-      , CONFIG_UPDATE
-      , REQUEST_ENTRIES
-      , REQUEST_LOG_INFO
+      // , REQUEST_ENTRIES
       } = require('../common/constants');
 
 assertConstantsDefined({
-  SERVER_RESPONSE_TIMEOUT
-, SERVER_ELECTION_GRACE_DELAY
-, RE_STATUS_NOT_LEADER
-, RE_STATUS_LAST
-, RE_STATUS_MORE
-, RE_STATUS_SNAPSHOT
+  SERVER_ELECTION_GRACE_DELAY
+// , RE_STATUS_NOT_LEADER
+// , RE_STATUS_LAST
+// , RE_STATUS_MORE
+// , RE_STATUS_SNAPSHOT
 }, 'number');
 
 assertConstantsDefined({
-  REQUEST_CONFIG
-, REQUEST_UPDATE
-, CONFIG_UPDATE
-, REQUEST_ENTRIES
-, REQUEST_LOG_INFO
+ // REQUEST_ENTRIES
 }, 'string', true);
 
-const requestConfigTypeBuf  = Buffer.from(REQUEST_CONFIG);
-const requestUpdateTypeBuf  = Buffer.from(REQUEST_UPDATE);
-const configUpdateTypeBuf   = Buffer.from(CONFIG_UPDATE);
-const requestEntriesTypeBuf = Buffer.from(REQUEST_ENTRIES);
-const requestLogInfoTypeBuf = Buffer.from(REQUEST_LOG_INFO);
+// const requestEntriesTypeBuf = Buffer.from(REQUEST_ENTRIES);
 
-const { createFramesProtocol } = require('../protocol');
+// const { createFramesProtocol } = require('../protocol');
 
-const requestConfigProtocol = createFramesProtocol('RequestConfig');
-const requestUpdateProtocol = createFramesProtocol('RequestUpdate');
-const configUpdateProtocol = createFramesProtocol('ConfigUpdate');
-const requestEntriesProtocol = createFramesProtocol('RequestEntries');
-const requestLogInfoProtocol = createFramesProtocol('RequestLogInfo');
+// const requestEntriesProtocol = createFramesProtocol('RequestEntries');
 
-const ZmqProtocolSocket = require('../client/zmq_protocol_socket');
+const ZmqRaftPeerClient = require('../client/zmq_raft_peer_client');
+const TimeoutError = ZmqRaftPeerClient.TimeoutError;
+const RequestEntriesStream = ZmqRaftPeerClient.RequestEntriesStream;
 
-const TimeoutError = ZmqProtocolSocket.TimeoutError;
-
-const secretBuf$ = Symbol('secretBuf');
 const rcPending$ = Symbol('rcPending');
 const timeout$   = Symbol('timeout');
 
 const debug = require('debug')('zmq-raft:client');
 
-function OutOfOrderError(message) {
-  Error.captureStackTrace(this, OutOfOrderError);
-  this.name = 'OutOfOrderError';
-  this.message = message || 'chunks received out of order';
-}
+// function OutOfOrderError(message) {
+//   Error.captureStackTrace(this, OutOfOrderError);
+//   this.name = 'OutOfOrderError';
+//   this.message = message || 'chunks received out of order';
+// }
 
-OutOfOrderError.prototype = Object.create(Error.prototype);
-OutOfOrderError.prototype.constructor = OutOfOrderError;
-OutOfOrderError.prototype.isOutOfOrder = true;
+// OutOfOrderError.prototype = Object.create(Error.prototype);
+// OutOfOrderError.prototype.constructor = OutOfOrderError;
+// OutOfOrderError.prototype.isOutOfOrder = true;
 
-
-class ZmqRaftClient extends ZmqProtocolSocket {
-
+/**
+ * This client executes RPC calls on the 0MQ Raft cluster.
+ * 
+ * Overrides the ZmqRaftPeerClient RPC methods making them resilient to singular peer failures.
+ * 
+ * The `timeout` argument of all the RPC methods also changes meaning.
+ * When the peer ZmqRaftPeerClient methods would just throw a timeout error waiting for the
+ * single response, the RPC methods of ZmqRaftClient would repeat requests, to every known peer
+ * in the cluster.
+ * 
+ * The `timeout` argument given to these RPC methods is an expiration timeout put on top
+ * of the whole procedure. The timeout error will be thrown after possible several attemps
+ * to contact several different cluster peers.
+ * 
+ * Also these RPC methods never throw PeerNotLeaderError. Instead they retry sending requests
+ * to the new leader. When the election is still pending a client gives a little time (grace delay)
+ * for the cluster to elect the new leader.
+**/
+class ZmqRaftClient extends ZmqRaftPeerClient {
   /**
-   * Create ZmqRaftClient
+   * Create an instance of ZmqRaftClient.
    *
    * `options` may be one of:
    *
-   * - `url` {String}: A seed url to fetch peer urls from via a Request Config RPC.
-   * - `urls` {Array}: An array of seed urls to fetch peers from via a Request Config RPC.
+   * - `url` {string}: A seed url to fetch peer urls from via a Request Config RPC.
+   * - `urls` {Array<string>}: An array of seed urls to fetch peers from via a Request Config RPC.
    * - `peers` {Array}: An array of established zmq raft server descriptors;
    *                    `peers` has precedence over `urls` and if provided the peer list
    *                    is not being fetched via Request Config RPC.
-   * - `secret` {String|Buffer}: A cluster identifying string which is sent and verified against
+   * - `secret` {string|Buffer}: A cluster identifying string which is sent and verified against
    *                             in each message.
-   * - `timeout` {number}: A time in milliseconds after which we consider a server peer as unresponsive.
+   * - `timeout` {number}: A time interval in milliseconds after which we consider a server peer as unresponsive.
+   *                       The request will be repeated if waiting for the response exceeds this interval.
+   *                       In this case the next request will be send to the new leader or the next
+   *                       peer in the cluster if the leader is not known.
+   * - `serverElectionGraceDelay` {number}: A delay in milliseconds to wait for the cluster
+   *                                        leader to elect before re-trying (default: 300).
    * - `lazy` {boolean}: Specify `true` to connect lazily on the first request.
    * - `heartbeat` {number}: How often, in milliseconds, to update cluster peer configuration
    *               via Request Config RPC; pass 0 to disable (default: 0); when establishing
@@ -109,10 +111,8 @@ class ZmqRaftClient extends ZmqProtocolSocket {
    *                   so if one of the peers goes down this many messages are possibly lost;
    *                   setting it prevents spamming a peer with expired messages when temporary
    *                   network partition occures (default: 2).
-   * - `serverElectionGraceDelay` {number}: A delay in milliseconds to wait for the Raft peers
-   *                                     to elect a new leader before retrying (default: 300).
    *
-   * @param {string|Array} [urls]
+   * @param {string|Array<string>} [urls]
    * @param {Object} [options]
    * @return {ZmqRaftClient}
   **/
@@ -134,17 +134,15 @@ class ZmqRaftClient extends ZmqProtocolSocket {
     else {
       urls = Array.from(peers.values());
     }
-    var options = Object.assign({timeout: SERVER_RESPONSE_TIMEOUT}, options);
 
     super(urls, options);
 
     this.peers = peers;
     this.leaderId = null;
-    this[secretBuf$] = Buffer.from(options.secret || '');
     this[timeout$] = new Set();
     this.serverElectionGraceDelay = (options.serverElectionGraceDelay|0) || SERVER_ELECTION_GRACE_DELAY;
     this.heartbeatMs = options.heartbeat|0;
-    if (this.heartbeatMs > 0) {// this[Symbol.for('connected')]
+    if (this.heartbeatMs > 0) {
       this.heartbeat = null;
       const heartbeat = (ms) => {
         if (this.heartbeat !== undefined) {
@@ -161,7 +159,7 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Disconnect, close socket and reject all pending requests
+   * Disconnect, close socket and reject all pending requests.
    *
    * @return {ZmqRaftClient}
   **/
@@ -174,10 +172,14 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Creates cancellable time delay promise
+   * Create a cancellable time delay promise.
    *
-   * @param {number} ms - delay interval
-   * @param {*} [result] - resolve argument
+   * The promise will resolve to the given `result` after the `ms` milliseconds.
+   * If the client would be closed before the promise is resolved, the promise
+   * will be rejected immediately with an Error.
+   *
+   * @param {number} ms - delay interval in milliseconds.
+   * @param {any} [result] - the resolve argument.
    * @return {Promise}
   **/
   delay(ms, result) {
@@ -198,21 +200,26 @@ class ZmqRaftClient extends ZmqProtocolSocket {
 
 
   /**
+   * The last known cluster config.
    * @property peers {Map}
   **/
 
   /**
+   * The last known cluster leader's ID.
    * @property leaderId {string|null}
   **/
 
   /**
-   * Set new leader
+   * Set the new leader.
    *
-   * will reconnect if necessary
+   * If the given `leaderId` is found in the cluster configuration only one connection to the
+   * leader's url will be sustained. Otherwise the client will connect to all the known peers
+   * in the cluster.
    *
-   * @param {string} [leaderId]
-   * @param {bool} [forceSetUrls]
-   * @return {Promise}
+   * @param {string|null} [leaderId] - the known leader ID or null.
+   * @param {boolean} [forceSetUrls] - forces re-checking connections regardless if leader ID
+   *                                   has changed or not.
+   * @return {this}
   **/
   setLeader(leaderId, forceSetUrls) {
     const peers = this.peers;
@@ -240,11 +247,16 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Set server peers and connect to the new ones and disconnect from the old ones
+   * Set the new cluster config.
+   *
+   * This call will update the last known cluster config and establish the connection
+   * according to the given `leaderId` argument.
+   *
+   * See ZmqRaftClient.prototype.setLeader for details on how the connections are set up.
    *
    * @param {Array} [peers]
    * @param {string} [leaderId]
-   * @return {Promise}
+   * @return {this}
   **/
   setPeers(peers, leaderId) {
     if (peers !== undefined) {
@@ -254,31 +266,35 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Send request config rpc
+   * Invoke RequestConfig RPC.
    *
-   * Resolves to {leaderId{string|null}, urls{Object}} on success.
+   * Resolves to {leaderId: string|null, urls: {id: url}} on success.
    *
-   * On success it will update internal peer urls
+   * The response will be accepted only from the current leader.
    *
-   * By default it will repeat requests forever until resolved or errored
+   * On success this method will update the last known cluster configuration.
    *
-   * @param {number} [timeout] in case there is a problem with reaching a peer after this timeout,
-   *                           the request is abandoned and resolves with `undefined`.
+   * @param {number} [timeout] - an interval in milliseconds, after which the request is
+   *                             abandoned and the returned promise resolves with `undefined`.
    * @return {Promise}
+   *
+   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
   requestConfig(timeout) {
     var expire;
     timeout |= 0;
     if (timeout !== 0) expire = now() + timeout;
-    const msg = [requestConfigTypeBuf, this[secretBuf$]]
-        , options = {protocol: requestConfigProtocol}
-        , request = () => {
-      return this.request(msg, options)
-      .then(([isLeader, leaderId, peers]) => {
+
+    const request = () => {
+      return super.requestConfig()
+      .then(({leaderId, isLeader, peers}) => {
         /* always update peers */
         this.setPeers(peers, leaderId);
         if (isLeader) {
-          this[rcPending$] = undefined;
+          if (expire === undefined) {
+            /* clear pending on request forever only */
+            this[rcPending$] = undefined;
+          }
           var urls = {};
           peers.forEach(([id, url]) => (urls[id] = url));
           return {leaderId, urls};
@@ -294,20 +310,23 @@ class ZmqRaftClient extends ZmqProtocolSocket {
       })
       .catch(err => {
         if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured trying to find another server');
+          debug('timeout occured re-trying config request with another server');
           this.setLeader(null);
           return request();
         }
         else {
-          this[rcPending$] = undefined;
+          if (expire === undefined) {
+            /* clear pending on request forever only */
+            this[rcPending$] = undefined;
+          }
           throw err;
         }
       });
     };
 
     /* ensure only one request config pending forever */
-    var pending = this[rcPending$];
     if (expire === undefined) {
+      let pending = this[rcPending$];
       if (pending !== undefined) return pending;
       else return this[rcPending$] = request();
     }
@@ -315,11 +334,11 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Send request log info rpc
+   * Invoke RequestLogInfo RPC.
    *
-   * Returned promise resolves to Object with the following properties:
+   * The returned promise resolves to an Object with the following properties:
    *
-   *  - isLeader {bool}
+   *  - isLeader {boolean}
    *  - leaderId {string|null}
    *  - currentTerm {number}
    *  - firstIndex {number}
@@ -329,64 +348,44 @@ class ZmqRaftClient extends ZmqProtocolSocket {
    *  - snapshotSize {number}
    *  - pruneIndex {number}
    *
-   * By default it will repeat requests forever until resolved or errored
    *
-   * @param {bool} anyPeer response from not a leader is ok
-   * @param {number} [timeout] in case there is a problem with reaching a peer after this timeout
-   *                           request is abandoned (rejected with TimeoutError)
+   * @param {boolean} anyPeer - whether a response from any peer will be accepted.
+   * @param {number} [timeout] - an interval in milliseconds, after which the request is
+   *                             abandoned and the returned promise resolves with `undefined`.
    * @return {Promise}
+   *
+   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
   requestLogInfo(anyPeer, timeout) {
     if (this.peers.size === 0) {
       return this.requestConfig(timeout).then(() => this.requestLogInfo(anyPeer, timeout));
     }
+
     var expire;
     timeout |= 0;
     if (timeout !== 0) expire = now() + timeout;
-    const msg = [requestLogInfoTypeBuf, this[secretBuf$]]
-        , options = {protocol: requestLogInfoProtocol}
-        , request = () => {
-      return this.request(msg, options)
-      .then(res => {
-        if (!anyPeer && !res[0]) {
-          /* not a leader, re-try */
-          this.setLeader(res[1]);
-          /* expire now if must */
-          if (expire !== undefined && now() >= expire)
-            throw new TimeoutError();
-          return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
-                                          .then(() => this.requestConfig(timeout)).then(request)
-                                        : request();
+
+    const request = () => {
+      return super.requestLogInfo()
+      .then(info => {
+        if (!anyPeer) {
+          this.setLeader(info.leaderId);
+          if (!info.isLeader) {
+            /* expire now if must */
+            if (expire !== undefined && now() >= expire)
+              throw new TimeoutError();
+            /* not a leader, re-try */
+            return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
+                                            .then(() => this.requestConfig(timeout)).then(request)
+                                          : request();
+          }
         }
-        var [
-          isLeader,
-          leaderId,
-          currentTerm,
-          firstIndex,
-          lastApplied,
-          commitIndex,
-          lastIndex,
-          snapshotSize,
-          pruneIndex
-        ] = res;
 
-        if (!anyPeer) this.setLeader(leaderId);
-
-        return {
-          isLeader,
-          leaderId,
-          currentTerm,
-          firstIndex,
-          lastApplied,
-          commitIndex,
-          lastIndex,
-          snapshotSize,
-          pruneIndex
-        };
+        return info;
       })
       .catch(err => {
         if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured trying to find another server');
+          debug('timeout occured re-trying log info request with another server');
           this.setLeader(null);
           return request();
         }
@@ -398,12 +397,9 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Send config update rpc
+   * Invoke ConfigUpdate RPC.
    *
-   * On success it will resolve to log index of the commited entry of Cold,new
-   *
-   * By default it will repeat requests (perhaps to many peers) until resolved
-   * or errored (expired).
+   * The returned promise resolves to the log index of the committed entry of Cold,new on success.
    *
    * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
    * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
@@ -413,70 +409,43 @@ class ZmqRaftClient extends ZmqProtocolSocket {
    *
    * You may use `utils.id.genIdent()` function to generate them.
    *
-   * @param {string|Buffer} id - update request id to ensure idempotent updates
-   * @param {Array} peers - new cluster configuration
-   * @param {number} [timeout] in case there is a problem with reaching a leader after this timeout
-   *                           request is abandoned (rejected with TimeoutError)
+   * @param {string|Buffer} id - a request ID to ensure idempotent updates.
+   * @param {Array} peers - the new cluster configuration.
+   * @param {number} [timeout] - an interval in milliseconds, after which the request is
+   *                             abandoned and the returned promise is rejected with TimeoutError.
    * @return {Promise}
+   *
+   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
   configUpdate(id, peers, timeout) {
-    if (id === undefined) return Promise.reject(new Error("configUpdate: required id argument is missing"));
     if (this.peers.size === 0) {
       return this.requestConfig(timeout).then(() => this.configUpdate(id, peers, timeout));
     }
+
     try {
-      peers = Array.from(parsePeers(peers));
+      peers = encodeMsgPack( Array.from(parsePeers(peers)) );
     } catch(err) { return Promise.reject(err); }
+
     var expire;
     timeout |= 0;
     if (timeout !== 0) expire = now() + timeout;
-    const msg = [configUpdateTypeBuf, this[secretBuf$], encodeMsgPack(peers)]
-        , options = {
-            id: id,
-            protocol: configUpdateProtocol,
-            onresponse: (res, reply, refresh) => {
-              /* response that update was accepted */
-              if (res[0] === 1 && res[1] === undefined) {
-                debug('accepted update');
-                refresh();
-              }
-              else return res;
-            }
-          }
-        , request = () => {
-      return this.request(msg, options)
-      .then(res => {
-        var status = res[0]
-          , arg = res[1];
-        /* response that update was commited */
-        if (status === 1) {
-          return arg;
-        }
-        /* configuration error */
-        else if (status === 2) {
-          throw new Error(arg.message);
-        }
-        /* cluster in transition */
-        else if (status === 3) {
-          throw new Error("configUpdate: cluster in configuration transition");
-        }
-        /* request id get too old */
-        else if (status !== 0) {
-          throw new Error("configUpdate: expired request id");
-        }
-        /* try the next server */
-        this.setLeader(arg);
-        /* expire now if must */
-        if (expire !== undefined && now() >= expire)
-          throw new TimeoutError();
-        /* continue */
-        return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
-                                        .then(() => this.requestConfig(timeout)).then(request)
-                                      : request();
-      })
+
+    const request = () => {
+      return super.configUpdate(id, peers)
       .catch(err => {
-        if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured trying to find another server');
+        if (err.isPeerNotLeader) {
+          /* try the next server */
+          this.setLeader(err.leaderId);
+          /* expire now if must */
+          if (expire !== undefined && now() >= expire)
+            throw new TimeoutError();
+          /* continue */
+          return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
+                                          .then(() => this.requestConfig(timeout)).then(request)
+                                        : request();          
+        }
+        else if (err.isTimeout && (expire === undefined || now() < expire)) {
+          debug('timeout occured re-trying config update request with another server');
           this.setLeader(null);
           return request();
         }
@@ -488,12 +457,9 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Send request update rpc
+   * Invoke RequestUpdate RPC.
    *
-   * On success it will resolve to a log index of the commited and applied entry
-   *
-   * By default it will repeat requests (perhaps to many peers) until resolved
-   * or errored (expired).
+   * The returned promise resolves to the log index of the committed entry.
    *
    * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
    * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
@@ -503,58 +469,37 @@ class ZmqRaftClient extends ZmqProtocolSocket {
    *
    * You may use `utils.id.genIdent()` function to generate them.
    *
-   * @param {string|Buffer} id - update request id to ensure idempotent updates
-   * @param {Buffer} data to append to the log
-   * @param {number} [timeout] in case there is a problem with reaching a leader after this timeout
-   *                           request is abandoned (rejected with TimeoutError)
+   * @param {string|Buffer} id - a request ID to ensure idempotent updates.
+   * @param {Buffer} data - log entry data to modify the state.
+   * @param {number} [timeout] - an interval in milliseconds, after which the request is
+   *                             abandoned and the returned promise is rejected with TimeoutError.
    * @return {Promise}
+   *
+   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
   **/
   requestUpdate(id, data, timeout) {
-    if (id === undefined) return Promise.reject(new Error("requestUpdate: required id argument is missing"));
     if (this.peers.size === 0) {
       return this.requestConfig(timeout).then(() => this.requestUpdate(id, data, timeout));
     }
     var expire;
     timeout |= 0;
     if (timeout !== 0) expire = now() + timeout;
-    const msg = [requestUpdateTypeBuf, this[secretBuf$], data]
-        , options = {
-            id: id,
-            protocol: requestUpdateProtocol,
-            onresponse: (res, reply, refresh) => {
-              /* response that update was accepted */
-              if (res[0] === true && res[1] === undefined) {
-                debug('accepted update');
-                refresh();
-              }
-              else return res;
-            }
-          }
-        , request = () => {
-      return this.request(msg, options)
-      .then(res => {
-        var arg = res[1];
-        /* response that update was commited */
-        if (res[0] === true) {
-          return arg;
-        }
-        /* request id get too old */
-        else if (arg === undefined) {
-          throw new Error("requestUpdate: expired request id");
-        }
-        /* try the next server */
-        this.setLeader(arg);
-        /* expire now if must */
-        if (expire !== undefined && now() >= expire)
-          throw new TimeoutError();
-        /* continue */
-        return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
-                                        .then(() => this.requestConfig(timeout)).then(request)
-                                      : request();
-      })
+    const request = () => {
+      return super.requestUpdate(id, data)
       .catch(err => {
-        if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured trying to find another server');
+        if (err.isPeerNotLeader) {
+          /* try the next server */
+          this.setLeader(err.leaderId);
+          /* expire now if must */
+          if (expire !== undefined && now() >= expire)
+            throw new TimeoutError();
+          /* continue */
+          return this.leaderId === null ? this.delay(this.serverElectionGraceDelay)
+                                          .then(() => this.requestConfig(timeout)).then(request)
+                                        : request();
+        }
+        else if (err.isTimeout && (expire === undefined || now() < expire)) {
+          debug('timeout occured re-trying log update request with another server');
           this.setLeader(null);
           return request();
         }
@@ -566,141 +511,89 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Perform request entries rpc
+   * Perform RequestEntries RPC.
    *
-   * Retrieve entries using `receiver` callback.
+   * Retrieve entries using the `receiver` callback.
    *
-   * On success it will resolve to true or false if canceled by the receiver.
+   * The received entries must be consumed ASAP and the retrieving of them can not be paused.
+   * However it is possible to cancel the request while processing entries.
    *
-   * By default it will repeat requests to all the known peers forever until resolved or errored.
+   * Use ZmqRaftClient.prototype.requestEntriesStream to work with the back-pressured streams instead.
    *
-   * `receiver` may modify entries array (e.g. clear it if has processed them).
-   * Stops receiving entries if the receiver returns false (exactly false, not falsyish).
+   * The returned promise will resolve to `true` if all of the requested entries were received.
+   * Otherwise the promise will resolve to `false` if the request was canceled by the receiver.
    *
-   * `receiver` signature:
-   * (status, entries or chunk{Array|Buffer}, lastIndex{number} [,
-   *   byteOffset{number}, snapshotSize{number}, isLastChunk{bool}, snapshotTerm{number}]) => bool
+   * The `receiver` function may modify its entries array argument (e.g. clear it).
+   * The `receiver` may request to stop receiving entries if the function returns `false`
+   * (that is an exact boolean `false`, not a falsy-ish value).
    *
-   * @param {number} lastIndex - index after which you need entries (last index of already received entry)
-   * @param {number} [count]
-   * @param {Function} receiver
-   * @param {number} [timeout] in case there is a problem with reaching a leader after this timeout
-   *                           request is abandoned (rejected with TimeoutError)
+   * The `receiver` function signature:
+   *   (status: number, entries_or_snapshot_chunk: Array|Buffer, lastIndex: number,
+   *    byteOffset?: number, snapshotSize?: number, isLastChunk?: boolean, snapshotTerm?: number
+   *   ) => false|any
+   *
+   * The `status` in this case may be one of:
+   *
+   * - 1: this is the last batch.
+   * - 2: expect more entries.
+   * - 3: this is a snapshot chunk.
+   *
+   * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
+   *                             (e.g. the index of the last received entry), specify 0 to start from 1.
+   * @param {number} [count] - the maximum number of requested entries, only valid if > 0; otherwise ignored.
+   * @param {Function} receiver - the function to process received entries.
+   * @param {number} [timeout] - an interval in milliseconds, after which the request is considered as
+   *                             expired and the returned promise may be rejected with TimeoutError.
+   * @param {number} [snapshotOffset] - a hint for the server to start responding with snapshot chunks
+   *           starting from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
    * @return {Promise}
+   *
+   * If the `timeout` is `0` or not specified the request will be retried indefinitely.
+   *
+   * The expiration timeout is checked agains only if the server does not respond within the RPC
+   * timeout interval, specified when the client was instantiated.
   **/
-  requestEntries(lastIndex, count, receiver, timeout) {
+  requestEntries(lastIndex, count, receiver, timeout, snapshotOffset) {
     if (this.peers.size === 0) {
-      return this.requestConfig(timeout).then(() => this.requestEntries(lastIndex, count, receiver, timeout));
+      return this.requestConfig(timeout)
+                 .then(() => this.requestEntries(lastIndex, count, receiver, timeout));
     }
     if ('function' === typeof count) {
-      timeout = receiver, receiver = count, count = undefined;
+      snapshotOffset = timeout, timeout = receiver, receiver = count, count = undefined;
     }
-    else {
-      count = +count;
-      if (!isFinite(count) || count <= 0) count = undefined;
-      if ('function' !== typeof receiver) return Promise.reject('receiver must be a function');
-    }
-    var expire, currentByte = 0, prevIndex = lastIndex;
+
+    var expire
+      , timeoutRPC = this.timeoutMs;
     timeout |= 0;
     if (timeout !== 0) expire = now() + timeout;
-    const msg = [requestEntriesTypeBuf, this[secretBuf$], lastIndex, count]
-        , timeoutMs = this.timeoutMs
-        , maxTimeoutMs = timeoutMs * 5
-        , options = {
-            timeout: timeoutMs,
-            protocol: requestEntriesProtocol,
-            onresponse: (res, reply, refresh) => {
-              var status = res[0]
-                , arg = res[1]
-                , isLastChunk
-                , byteOffset, snapshotSize, snapshotTerm, chunk
-                , numEntries
-                , ret;
-
-              switch(status) {
-              case RE_STATUS_NOT_LEADER:
-                /* try next server */
-                this.setLeader(arg);
-                return null;
-              case RE_STATUS_MORE:
-              case RE_STATUS_LAST:
-              case RE_STATUS_SNAPSHOT:
-                /* copy lastIndex from response */
-                lastIndex = res[2];
-                /* push entries to result */
-                if (status === RE_STATUS_SNAPSHOT) {
-                  status = RE_STATUS_MORE;
-                  byteOffset = arg[0];
-                  snapshotSize = arg[1];
-                  snapshotTerm = arg[2];
-                  chunk = res[3];
-                  if (currentByte !== byteOffset) throw new OutOfOrderError("ZmqRaftClient.requestEntries: snapshot chunks not in order");
-                  currentByte = byteOffset + chunk.length;
-                  isLastChunk = currentByte === snapshotSize;
-                  ret = receiver(status, chunk, lastIndex, byteOffset, snapshotSize, isLastChunk, snapshotTerm);
-                  if (isLastChunk) {
-                    msg[2] = lastIndex;
-
-                    if (count !== undefined) {
-                      if (count === 1) status = RE_STATUS_LAST;
-                      msg[3] = --count;
-                    }
-                  }
-                }
-                else {
-                  msg[2] = lastIndex;
-                  res.splice(0, 3);
-                  numEntries = res.length;
-                  if (lastIndex - numEntries !== prevIndex) throw new OutOfOrderError("ZmqRaftClient.requestEntries: entries not in order");
-                  ret = receiver(status, res, lastIndex);
-                  if (count !== undefined) msg[3] = (count -= numEntries);
-                }
-
-                prevIndex = lastIndex;
-
-                if (status === RE_STATUS_MORE) {
-                  /* request more or ask to stop */
-                  if (ret === false || count <= 0) {
-                    status = RE_STATUS_LAST;
-                    /* set count = 0 to stop streaming from the server */
-                    msg[3] = 0;
-                  } else refresh();
-                  reply(msg);
-                }
-
-                if (status === RE_STATUS_LAST) return ret !== false;
-
-                break;
-
-              default:
-                throw new Error("unknown status");
-              }
-            }
-          }
+    const maxTimeoutRPC = timeoutRPC * 5
         , request = () => {
-      return this.request(msg, options)
-      .then(result => {
-        /* all received */
-        if (result !== null) {
-          return result;
-        }
-        /* expire now if must */
-        if (expire !== undefined && now() >= expire)
-          throw new TimeoutError();
-        /* continue */
-        if (this.leaderId === null) { /* election in progress */
-          options.timeout = timeoutMs; /* reset timeout */
-          return this.delay(this.serverElectionGraceDelay)
-                .then(() => this.requestConfig(timeout)).then(request);
-        }
-        else return request();
-      })
+      return super.requestEntries(lastIndex, count, receiver, timeoutRPC, snapshotOffset)
       .catch(err => {
-        if (err.isTimeout && (expire === undefined || now() < expire)) {
-          debug('timeout occured trying to find another server');
+        var state = err.requestEntriesState;
+        lastIndex      = state.lastIndex;
+        count          = state.count;
+        snapshotOffset = state.snapshotOffset;
+
+        if (err.isPeerNotLeader) {
+          /* try the next server */
+          this.setLeader(err.leaderId);
+          /* expire now if must */
+          if (expire !== undefined && now() >= expire)
+            throw new TimeoutError();
+          /* continue */
+          if (this.leaderId === null) { /* election in progress */
+            timeoutRPC = this.timeoutMs; /* reset timeout */
+            return this.delay(this.serverElectionGraceDelay)
+                  .then(() => this.requestConfig(timeout)).then(request);
+          }
+          else return request();
+        }
+        else if (err.isTimeout && (expire === undefined || now() < expire)) {
+          debug('timeout occured re-trying entries request with another server');
           this.setLeader(null);
           /* increase timeout, to prevent streaming timeout loop */
-          if ((options.timeout += timeoutMs) > maxTimeoutMs) options.timeout = maxTimeoutMs;
+          if ((timeoutRPC += this.timeoutMs) > maxTimeoutRPC) timeoutRPC = maxTimeoutRPC;
           return request();
         }
         else throw err;
@@ -711,31 +604,36 @@ class ZmqRaftClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Returns request entries rpc readable stream
+   * Returns a Readable stream that retrieves entries via the RequestEntries RPC.
    *
-   * The returned stream is lazy and can be back-pressured.
-   * RequestEntries RPC are sent to the cluster only when data is requested via stream.Readable api.
+   * The returned stream is lazy: RequestEntries RPC messages are sent to the cluster only when
+   * data is requested via stream.Readable api.
    *
-   * The data provided by the stream is either common.LogEntry or common.SnapshotChunk instances.
+   * The returned stream can be back-pressured.
    *
-   * By default it will repeat requests to all the known peers forever until resolved or errored.
+   * The stream yields objects that are instances of either common.LogEntry or common.SnapshotChunk.
    *
-   * options:
+   * `options`:
    *
-   * - `count` {number} - maximum number of requested entries
-   * - `timeout` {number} - in case there is a problem with reaching a leader after this timeout
-   *                        request is abandoned (error event is emited on stream with TimeoutError argument)
+   * - `count` {number} - the maximum number of requested entries, only valid if > 0; otherwise ignored.
+   * - `timeout` {number} - an interval in milliseconds, after which the request is considered as
+   *                        expired and the "error" event may be emitted with the TimeoutError argument.
+   * - `snapshotOffset` {number} - a hint for the server to start responding with snapshot chunks starting
+   *                  from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
    *
-   * @param {number} lastIndex - index after which you need entries (last index of already received entry)
+   * Any other option is passed to the Readable constructor.
+   *
+   * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
+   *                             (e.g. the index of the last received entry), specify 0 to start from 1.
    * @param {number|Object} [count|options]
-   * @return {Readable}
+   * @return {RequestEntriesStream}
   **/
   requestEntriesStream(lastIndex, options) {
     return new RequestEntriesStream(this, lastIndex, options);
   }
 
 }
-
+/*
 class RequestEntriesStream extends Readable {
   constructor(client, lastIndex, options) {
     var count, timeout;
@@ -773,15 +671,14 @@ class RequestEntriesStream extends Readable {
 
       switch(status) {
       case RE_STATUS_NOT_LEADER:
-        /* try next server */
-        client.setLeader(arg);
-        return null;
+        // try next server
+        return arg;
       case RE_STATUS_MORE:
       case RE_STATUS_LAST:
       case RE_STATUS_SNAPSHOT:
-        /* copy lastIndex from response */
+        // copy lastIndex from response
         lastIndex = res[2];
-        /* handle snapshots */
+        // handle snapshots
         if (status === RE_STATUS_SNAPSHOT) {
           status = RE_STATUS_MORE;
 
@@ -794,7 +691,7 @@ class RequestEntriesStream extends Readable {
           chunk = bufferToSnapshotChunk(chunk, lastIndex, byteOffset, snapshotSize, snapshotTerm);
           more = this.push(chunk);
 
-          /* snapshot last chunk */
+          // snapshot last chunk
           if (currentByte === snapshotSize) {
             msg[2] = lastIndex;
             if (count !== undefined) {
@@ -807,13 +704,13 @@ class RequestEntriesStream extends Readable {
             }
           }
           else {
-            /* not a last chunk */
+            // not a last chunk
             if (count === undefined) msg[3] = null;
             msg[4] = currentByte;
           }
         }
         else {
-          /* handle entries */
+          // handle entries
           let numEntries = res.length - 3;
           if (lastIndex - numEntries !== prevIndex) throw new OutOfOrderError("ZmqRaftClient.requestEntries: entries not in order");
           for(let i = 1; i <= numEntries; ++i) {
@@ -828,25 +725,25 @@ class RequestEntriesStream extends Readable {
         prevIndex = lastIndex;
 
         if (status === RE_STATUS_MORE) {
-          /* request more or ask to stop */
+          // request more or ask to stop
           if (count <= 0) {
-            /* set count = 0 to stop streaming from the server and finish */
+            // set count = 0 to stop streaming from the server and finish
             msg[3] = 0;
             if (queue.length !== 0) this._consumeReplyQueue();
             reply(msg);
-            /* finish request */
+            // finish request
             return true;
           } else if (more) {
-            /* reply asking for more */
+            // reply asking for more
             if (queue.length !== 0) this._consumeReplyQueue();
             refresh();
             reply(msg);
           } else {
-            /* back pressured */
-            /* prevent request timeout */
+            // back pressured
+            // prevent request timeout
             refresh(0);
             let msgclone = msg.slice(0);
-            /* postpone replying */
+            // postpone replying
             queue.push(() => {
               refresh(options.timeout);
               reply(msgclone);
@@ -854,7 +751,7 @@ class RequestEntriesStream extends Readable {
           }
         }
         else {
-          /* last response: finish request */
+          // last response: finish request
           if (queue.length !== 0) this._consumeReplyQueue();
           return true;
         }
@@ -868,17 +765,19 @@ class RequestEntriesStream extends Readable {
 
     const request = () => client.request(msg, options)
       .then(result => {
-        /* all received */
-        if (result !== null) {
+        // all received
+        if (result === true) {
           this.push(null);
           return;
         }
-        /* expire now if must */
+        // not a leader
+        client.setLeader(result);
+        // expire now if must
         if (expire !== undefined && now() >= expire)
           throw new TimeoutError();
-        /* continue */
-        if (client.leaderId === null) { /* election in progress */
-          options.timeout = timeoutMs; /* reset timeout */
+        // continue
+        if (client.leaderId === null) { // election in progress
+          options.timeout = timeoutMs; // reset timeout
           return client.delay(client.serverElectionGraceDelay)
                 .then(() => client.requestConfig(timeout)).then(request);
         }
@@ -888,7 +787,7 @@ class RequestEntriesStream extends Readable {
         if (err.isTimeout && (expire === undefined || now() < expire)) {
           debug('timeout occured trying to find another server');
           client.setLeader(null);
-          /* increase timeout, to prevent streaming timeout loop */
+          // increase timeout, to prevent streaming timeout loop
           if ((options.timeout += timeoutMs) > maxTimeoutMs) options.timeout = maxTimeoutMs;
           return request();
         }
@@ -915,8 +814,8 @@ class RequestEntriesStream extends Readable {
     queue.length = 0;
   }
 }
-
-ZmqRaftClient.OutOfOrderError = OutOfOrderError;
+*/
+// ZmqRaftClient.OutOfOrderError = OutOfOrderError;
 ZmqRaftClient.ZmqRaftClient = ZmqRaftClient;
 ZmqRaftClient.TimeoutError = TimeoutError;
 ZmqRaftClient.RequestEntriesStream = RequestEntriesStream;

--- a/lib/client/zmq_raft_peer_client.js
+++ b/lib/client/zmq_raft_peer_client.js
@@ -355,12 +355,15 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
    * Otherwise the promise will resolve to `false` if the request was canceled by the receiver.
    *
    * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
-   * raft state is other than the LEADER. It may be possible even if some entries has been
+   * raft state is other than the LEADER. It may be possible even if some entries have been
    * already received.
    *
    * If the promise is rejected with any error, that error will have a property `requestEntriesState`
-   * set to a value with the following properties `{lastIndex: number, count?: number}`, which
-   * can be used for the request continuation.
+   * set to a value with the following properties:
+   * - lastIndex {number}
+   * - [count] {number}
+   * - [snapshotOffset] {number}
+   * which can be used for the request continuation.
    *
    * The `receiver` function may modify its entries array argument (e.g. clear it).
    * The `receiver` may request to stop receiving entries if the function returns `false`
@@ -396,7 +399,9 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
     else {
       count = +count;
       if (!isFinite(count) || count <= 0) count = undefined;
-      if ('function' !== typeof receiver) return Promise.reject('receiver must be a function');
+      if ('function' !== typeof receiver) {
+        return Promise.reject(new TypeError('receiver must be a function'));
+      }
     }
     var currentByte = parseInt(snapshotOffset)||0
       , prevIndex = lastIndex;

--- a/lib/client/zmq_raft_peer_client.js
+++ b/lib/client/zmq_raft_peer_client.js
@@ -1,0 +1,629 @@
+/* 
+ *  Copyright (c) 2020 Rafał Michalski <royal@yeondir.com>
+ */
+"use strict";
+
+const isArray = Array.isArray;
+
+const assert = require('assert');
+
+const { Readable } = require('stream');
+
+const { encode: encodeMsgPack } = require('msgpack-lite');
+
+const { assertConstantsDefined, parsePeers } = require('../utils/helpers');
+const { bufferToLogEntry } = require('../common/log_entry');
+const { bufferToSnapshotChunk } = require('../common/snapshot_chunk');
+
+/* expect response within this timeout, if not will try the next server */
+const { SERVER_RESPONSE_TIMEOUT
+
+      , RE_STATUS_NOT_LEADER
+      , RE_STATUS_LAST
+      , RE_STATUS_MORE
+      , RE_STATUS_SNAPSHOT
+
+      , REQUEST_CONFIG
+      , REQUEST_UPDATE
+      , CONFIG_UPDATE
+      , REQUEST_ENTRIES
+      , REQUEST_LOG_INFO
+      } = require('../common/constants');
+
+assertConstantsDefined({
+  SERVER_RESPONSE_TIMEOUT
+, RE_STATUS_NOT_LEADER
+, RE_STATUS_LAST
+, RE_STATUS_MORE
+, RE_STATUS_SNAPSHOT
+}, 'number');
+
+assertConstantsDefined({
+  REQUEST_CONFIG
+, REQUEST_UPDATE
+, CONFIG_UPDATE
+, REQUEST_ENTRIES
+, REQUEST_LOG_INFO
+}, 'string', true);
+
+const requestConfigTypeBuf  = Buffer.from(REQUEST_CONFIG);
+const requestUpdateTypeBuf  = Buffer.from(REQUEST_UPDATE);
+const configUpdateTypeBuf   = Buffer.from(CONFIG_UPDATE);
+const requestEntriesTypeBuf = Buffer.from(REQUEST_ENTRIES);
+const requestLogInfoTypeBuf = Buffer.from(REQUEST_LOG_INFO);
+
+const { createFramesProtocol } = require('../protocol');
+
+const requestConfigProtocol = createFramesProtocol('RequestConfig');
+const requestUpdateProtocol = createFramesProtocol('RequestUpdate');
+const configUpdateProtocol = createFramesProtocol('ConfigUpdate');
+const requestEntriesProtocol = createFramesProtocol('RequestEntries');
+const requestLogInfoProtocol = createFramesProtocol('RequestLogInfo');
+
+const ZmqProtocolSocket = require('../client/zmq_protocol_socket');
+
+const TimeoutError = ZmqProtocolSocket.TimeoutError;
+
+const secretBuf$ = Symbol('secretBuf');
+const request$ = Symbol('request');
+
+const debug = require('debug')('zmq-raft:peer-client');
+
+function PeerNotLeaderError(leaderId) {
+  Error.captureStackTrace(this, PeerNotLeaderError);
+  this.name = 'PeerNotLeaderError';
+  this.message = 'the peer is not the leader';
+  this.leaderId = leaderId || null;
+}
+
+PeerNotLeaderError.prototype = Object.create(Error.prototype);
+PeerNotLeaderError.prototype.constructor = PeerNotLeaderError;
+PeerNotLeaderError.prototype.isPeerNotLeader = true;
+
+function OutOfOrderError(message) {
+  Error.captureStackTrace(this, OutOfOrderError);
+  this.name = 'OutOfOrderError';
+  this.message = message || 'chunks received out of order';
+}
+
+OutOfOrderError.prototype = Object.create(Error.prototype);
+OutOfOrderError.prototype.constructor = OutOfOrderError;
+OutOfOrderError.prototype.isOutOfOrder = true;
+
+/**
+ * This client executes RPC calls on a single 0MQ Raft Peer.
+ **/
+class ZmqRaftPeerClient extends ZmqProtocolSocket {
+  /**
+   * Create an instance of ZmqRaftPeerClient.
+   *
+   * `options` may be one of:
+   *
+   * - `url` {string}: A single cluster peer url to connect directly to.
+   * - `urls` {Array<string>}: An array of url peers; each request will be send to each one of them
+   *                           in a round-robin order.
+   * - `secret` {string|Buffer}: A cluster identifying string which is sent and verified against
+   *                             in each message.
+   * - `timeout` {number}: A default time interval in milliseconds after which we consider a server
+   *                       unresponsive; the request will timeout if waiting for the response exceeds
+   *                       this interval; 0 disables request timeout - in this instance the response
+   *                       is waited for indefinitely; the default is 500 ms.
+   * - `lazy` {boolean}: Specify `true` to connect lazily on the first request.
+   * - `sockopts` {Object}: Specify zeromq socket options as an object e.g.: `{ZMQ_IPV4ONLY: true}`.
+   * - `highwatermark` {number}: A shortcut to specify `ZMQ_SNDHWM` socket option for an underlying
+   *                   zeromq DEALER socket; this affects how many messages are queued per server
+   *                   so if one of the peers goes down this many messages are possibly lost;
+   *                   setting it prevents spamming a peer with expired messages when temporary
+   *                   network partition occures (default: 2).
+   *
+   * @param {string|Array<string>} [urls]
+   * @param {Object} [options]
+   * @return {ZmqRaftPeerClient}
+  **/
+  constructor(urls, options) {
+    if (urls && !isArray(urls) && 'object' === typeof urls) {
+      options = urls, urls = undefined;
+    }
+    options || (options = {});
+    if (!options && 'object' !== typeof options)
+      throw TypeError('ZmqRaftPeerClient: options must be an object');
+    options = Object.assign({timeout: SERVER_RESPONSE_TIMEOUT}, options);
+
+    super(urls, options);
+
+    this[secretBuf$] = Buffer.from(options.secret || '');
+  }
+
+  /**
+   * Disconnect, close socket and reject all pending requests.
+   *
+   * @return {ZmqRaftPeerClient}
+  **/
+  // close() {
+  //   return super.close();
+  // }
+
+  /**
+   * Invoke RequestConfig RPC.
+   *
+   * Resolves to {leaderId: string|null, isLeader: boolean, peers: [[id, url]]} on success.
+   *
+   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
+   *                 the request is abandoned and the promise is rejected with TimeoutError;
+   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * @return {Promise}
+  **/
+  requestConfig(timeout) {
+    const msg = [requestConfigTypeBuf, this[secretBuf$]]
+        , options = {protocol: requestConfigProtocol, timeout};
+
+    return this.request(msg, options)
+    .then(([isLeader, leaderId, peers]) => {
+      return {leaderId, isLeader, peers};
+    });
+  }
+
+  /**
+   * Invoke RequestLogInfo RPC.
+   *
+   * The returned promise resolves to an Object with the following properties:
+   *
+   *  - isLeader {boolean}
+   *  - leaderId {string|null}
+   *  - currentTerm {number}
+   *  - firstIndex {number}
+   *  - lastApplied {number}
+   *  - commitIndex {number}
+   *  - lastIndex {number}
+   *  - snapshotSize {number}
+   *  - pruneIndex {number}
+   *
+   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
+   *                 the request is abandoned and the promise is rejected with TimeoutError;
+   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * @return {Promise}
+  **/
+  requestLogInfo(timeout) {
+    const msg = [requestLogInfoTypeBuf, this[secretBuf$]]
+        , options = {protocol: requestLogInfoProtocol, timeout};
+
+    return this.request(msg, options)
+    .then(res => {
+      var [
+        isLeader,
+        leaderId,
+        currentTerm,
+        firstIndex,
+        lastApplied,
+        commitIndex,
+        lastIndex,
+        snapshotSize,
+        pruneIndex
+      ] = res;
+
+      return {
+        isLeader,
+        leaderId,
+        currentTerm,
+        firstIndex,
+        lastApplied,
+        commitIndex,
+        lastIndex,
+        snapshotSize,
+        pruneIndex
+      };
+    });
+  }
+
+  /**
+   * Invoke ConfigUpdate RPC.
+   *
+   * The returned promise resolves to the log index of the committed entry of Cold,new on success.
+   *
+   * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
+   * raft state is other than the LEADER.
+   *
+   * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
+   * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
+   * `id` should be freshly generated. Its "the seconds" part is important
+   * because update requests might expire after `common.constants.DEFAULT_REQUEST_ID_TTL`
+   * milliseconds.
+   *
+   * You may use `utils.id.genIdent()` function to generate them.
+   *
+   * @param {string|Buffer} id - a request ID to ensure idempotent updates.
+   * @param {Array|Buffer} peers - the new cluster configuration.
+   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
+   *                 the request is abandoned and the promise is rejected with TimeoutError;
+   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * @return {Promise}
+  **/
+  configUpdate(id, peers, timeout) {
+    if (id === undefined) return Promise.reject(new Error("configUpdate: required id argument is missing"));
+    if (!Buffer.isBuffer(peers)) {
+      try {
+        peers = encodeMsgPack( Array.from(parsePeers(peers)) );
+      } catch(err) { return Promise.reject(err); }
+    }
+    const msg = [configUpdateTypeBuf, this[secretBuf$], peers]
+        , options = {
+            id,
+            timeout,
+            protocol: configUpdateProtocol,
+            onresponse: (res, reply, refresh) => {
+              /* response that update was accepted */
+              if (res[0] === 1 && res[1] === undefined) {
+                debug('accepted update');
+                refresh();
+              }
+              else return res;
+            }
+          };
+
+    return this.request(msg, options)
+    .then(res => {
+      var status = res[0]
+        , arg = res[1];
+      /* response that update was committed */
+      if (status === 1) {
+        return arg;
+      }
+      /* configuration error */
+      else if (status === 2) {
+        throw new Error(arg.message);
+      }
+      /* cluster in transition */
+      else if (status === 3) {
+        throw new Error("configUpdate: cluster in configuration transition");
+      }
+      /* request id get too old */
+      else if (status !== 0) {
+        throw new Error("configUpdate: expired request id");
+      }
+      /* not a leader */
+      throw new PeerNotLeaderError(arg);
+    });
+  }
+
+  /**
+   * Invoke RequestUpdate RPC.
+   *
+   * The returned promise resolves to the log index of the committed entry.
+   *
+   * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
+   * raft state is other than the LEADER.
+   *
+   * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
+   * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
+   * `id` should be freshly generated. Its "the seconds" part is important
+   * because update requests might expire after `common.constants.DEFAULT_REQUEST_ID_TTL`
+   * milliseconds.
+   *
+   * You may use `utils.id.genIdent()` function to generate them.
+   *
+   * @param {string|Buffer} id - a request ID to ensure idempotent updates.
+   * @param {Buffer} data - log entry data to modify the state.
+   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
+   *                 the request is abandoned and the promise is rejected with TimeoutError;
+   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * @return {Promise}
+  **/
+  requestUpdate(id, data, timeout) {
+    if (id === undefined) return Promise.reject(new Error("requestUpdate: required id argument is missing"));
+    const msg = [requestUpdateTypeBuf, this[secretBuf$], data]
+        , options = {
+            id,
+            timeout,
+            protocol: requestUpdateProtocol,
+            onresponse: (res, reply, refresh) => {
+              /* response that update was accepted */
+              if (res[0] === true && res[1] === undefined) {
+                debug('accepted update');
+                refresh();
+              }
+              else return res;
+            }
+          };
+
+    return this.request(msg, options)
+    .then(res => {
+      var arg = res[1];
+      /* response that update was committed */
+      if (res[0] === true) {
+        return arg;
+      }
+      /* request id get too old */
+      else if (arg === undefined) {
+        throw new Error("requestUpdate: expired request id");
+      }
+      /* not a leader */
+      throw new PeerNotLeaderError(arg);
+    });
+  }
+
+  /**
+   * Perform RequestEntries RPC.
+   *
+   * Retrieve entries using the `receiver` callback.
+   *
+   * The received entries must be consumed ASAP and the retrieving of them can not be paused.
+   * However it is possible to cancel the request while processing entries.
+   *
+   * Use ZmqRaftPeerClient.prototype.requestEntriesStream to work with the back-pressured streams instead.
+   *
+   * The returned promise will resolve to `true` if all of the requested entries were received.
+   * Otherwise the promise will resolve to `false` if the request was canceled by the receiver.
+   *
+   * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
+   * raft state is other than the LEADER. It may be possible even if some entries has been
+   * already received.
+   *
+   * If the promise is rejected with any error, that error will have a property `requestEntriesState`
+   * set to a value with the following properties `{lastIndex: number, count?: number}`, which
+   * can be used for the request continuation.
+   *
+   * The `receiver` function may modify its entries array argument (e.g. clear it).
+   * The `receiver` may request to stop receiving entries if the function returns `false`
+   * (that is an exact boolean `false`, not a falsy-ish value).
+   *
+   * The `receiver` function signature:
+   *   (status: number, entries_or_snapshot_chunk: Array|Buffer, lastIndex: number,
+   *    byteOffset?: number, snapshotSize?: number, isLastChunk?: boolean, snapshotTerm?: number
+   *   ) => false|any
+   *
+   * The `status` in this case may be one of:
+   *
+   * - 1: this is the last batch.
+   * - 2: expect more entries.
+   * - 3: this is a snapshot chunk.
+   *
+   * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
+   *                             (e.g. the index of the last received entry), specify 0 to start from 1.
+   * @param {number} [count] - the maximum number of requested entries, only valid if > 0; otherwise ignored.
+   * @param {Function} receiver - the function to process received entries.
+   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
+   *                 the request is abandoned and the promise is rejected with TimeoutError;
+   *                 if this is 0, null or undefined, the default timeout is used instead;
+   *                 each received response restarts the timeout counter.
+   * @param {number} [snapshotOffset] - a hint for the server to start responding with snapshot chunks
+   *           starting from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
+   * @return {Promise}
+  **/
+  requestEntries(lastIndex, count, receiver, timeout, snapshotOffset) {
+    if ('function' === typeof count) {
+      timeout = receiver, receiver = count, count = undefined;
+    }
+    else {
+      count = +count;
+      if (!isFinite(count) || count <= 0) count = undefined;
+      if ('function' !== typeof receiver) return Promise.reject('receiver must be a function');
+    }
+    var currentByte = parseInt(snapshotOffset)||0
+      , prevIndex = lastIndex;
+    if (currentByte < 0) currentByte = 0;
+    const msg = [requestEntriesTypeBuf, this[secretBuf$], lastIndex]
+        , options = {
+            timeout,
+            protocol: requestEntriesProtocol,
+            onresponse: (res, reply, refresh) => {
+              var status = res[0]
+                , arg = res[1]
+                , isLastChunk
+                , byteOffset, snapshotSize, snapshotTerm, chunk
+                , numEntries
+                , ret;
+
+              switch(status) {
+              case RE_STATUS_NOT_LEADER:
+                /* not a leader */
+                return arg;
+              case RE_STATUS_MORE:
+              case RE_STATUS_LAST:
+              case RE_STATUS_SNAPSHOT:
+                /* copy lastIndex from response */
+                lastIndex = res[2];
+                /* push entries to result */
+                if (status === RE_STATUS_SNAPSHOT) {
+                  status = RE_STATUS_MORE;
+                  byteOffset = arg[0];
+                  snapshotSize = arg[1];
+                  snapshotTerm = arg[2];
+                  chunk = res[3];
+                  if (currentByte !== byteOffset) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: snapshot chunks not in order");
+                  currentByte = byteOffset + chunk.length;
+                  isLastChunk = currentByte === snapshotSize;
+                  ret = receiver(status, chunk, lastIndex, byteOffset, snapshotSize, isLastChunk, snapshotTerm);
+                  if (isLastChunk) {
+                    msg[2] = lastIndex;
+
+                    if (count !== undefined) {
+                      if (count === 1) status = RE_STATUS_LAST;
+                      msg[3] = --count;
+                      msg.length = 4;
+                    }
+                    else {
+                      msg.length = 3;
+                    }
+                  }
+                  else { /* not the last chunk */
+                    if (count === undefined) msg[3] = null;
+                    msg[4] = currentByte;
+                  }
+                }
+                else { /* handle log entries */
+                  if (msg.length === 5) {
+                    msg.length = (count !== undefined) ? 4 : 3;
+                  }
+                  msg[2] = lastIndex;
+                  res.splice(0, 3);
+                  numEntries = res.length;
+                  if (lastIndex - numEntries !== prevIndex) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: entries not in order");
+                  ret = receiver(status, res, lastIndex);
+                  if (count !== undefined) msg[3] = (count -= numEntries);
+                }
+
+                prevIndex = lastIndex;
+
+                if (status === RE_STATUS_MORE) {
+                  /* request more or ask to stop */
+                  if (ret === false || count <= 0) {
+                    /* set count = 0 to stop streaming from the server */
+                    msg[3] = 0;
+                  } else {
+                    refresh(); /* restart timeout */
+                  }
+                  reply(msg);
+                  if (count <= 0) return true; /* the last entry received */
+                  if (ret === false) return false; /* cancel before the last entry */
+                }
+                else if (status === RE_STATUS_LAST) {
+                  return true; /* the last entry received */
+                }
+
+                break;
+
+              default:
+                throw new Error("unknown status");
+              }
+            }
+          };
+
+    if (count !== undefined) {
+      msg.push(count);
+    }
+    else if (currentByte !== 0) {
+      msg.push(null);
+    }
+    if (currentByte !== 0) msg.push(currentByte);
+
+    return this.request(msg, options)
+    .then(result => {
+      /* all received */
+      if (typeof result === 'boolean') {
+        return result;
+      }
+      /* not a leader */
+      throw new PeerNotLeaderError(result);
+    })
+    .catch(err => {
+      /* attach the state so the request can be continued from another peer */
+      err.requestEntriesState = {lastIndex: msg[2], count: msg[3], snapshotOffset: msg[4]};
+      throw err;
+    });
+  }
+
+  /**
+   * Returns a Readable stream that retrieves entries via the RequestEntries RPC.
+   *
+   * The returned stream is lazy: RequestEntries RPC messages are sent to the cluster only when
+   * data is requested via stream.Readable api.
+   *
+   * The returned stream can be back-pressured.
+   *
+   * The stream yields objects that are instances of either common.LogEntry or common.SnapshotChunk.
+   *
+   * `options`:
+   *
+   * - `count` {number} - the maximum number of requested entries, only valid if > 0; otherwise ignored.
+   * - `timeout` {number} - an override timeout interval in milliseconds, after which the request
+   *                is abandoned and the stream will emit an "error" event with the TimeoutError argument;
+   *                if this is 0, null or undefined, the default timeout is used instead;
+   *                each received response restarts the timeout counter.
+   * - `snapshotOffset` {number} - a hint for the server to start responding with snapshot chunks starting
+   *                  from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
+   *
+   * Any other option is passed to the Readable constructor.
+   *
+   * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
+   *                             (e.g. the index of the last received entry), specify 0 to start from 1.
+   * @param {number|Object} [count|options]
+   * @return {RequestEntriesStream}
+  **/
+  requestEntriesStream(lastIndex, options) {
+    return new RequestEntriesStream(this, lastIndex, options);
+  }
+
+}
+
+class RequestEntriesStream extends Readable {
+  constructor(client, prevIndex, options) {
+    var count, snapshotOffset, timeout;
+    if ('number' === typeof options) {
+      count = options;
+      options = undefined;
+    }
+    else if (options) {
+      count = options.count;
+      timeout = options.timeout;
+      snapshotOffset = options.snapshotOffset;
+    }
+    count = +count;
+    if (!isFinite(count) || count <= 0) count = undefined;
+
+    var index0 = prevIndex;
+
+    super(Object.assign({}, options, {objectMode: true}));
+
+    const receiver = (status, chunk, lastIndex, byteOffset, snapshotSize, isLastChunk, snapshotTerm) => {
+      var more = true;
+      if (status === RE_STATUS_SNAPSHOT) {
+        if (isLastChunk) {
+          prevIndex = lastIndex;
+          snapshotOffset = undefined;
+        }
+        else {
+          snapshotOffset = byteOffset + chunk.length;
+        }
+        more = this.push(
+          bufferToSnapshotChunk(chunk, lastIndex, byteOffset, snapshotSize, snapshotTerm)
+        );
+      }
+      else {
+        prevIndex = lastIndex;
+        const numEntries = chunk.length;
+        let index = lastIndex - numEntries;
+        for(let i = 0; i < numEntries; ++i) {
+          more = this.push(
+            bufferToLogEntry(chunk[i], ++index)
+          );
+        }
+      }
+      return more;
+    };
+
+    const request = this[request$] = () => {
+      this[request$] = null;
+      debug("request entries stream start %s, %s (%s)", prevIndex, count, snapshotOffset);
+      return client.requestEntries(prevIndex, count, receiver, timeout, snapshotOffset)
+      .then(res => {
+        if (res) {
+          /* EOS */
+          debug("request entries stream end");
+          this.push(null);
+        }
+        else { /* back-pressured */
+          debug("request entries stop");
+          if (count !== undefined) {
+            count -= prevIndex - index0;
+            index0 = prevIndex;
+          }
+          this[request$] = request;
+        }
+      });
+    };
+  }
+
+  _read(_size) {
+    var request = this[request$];
+    if (request != null) {
+      request().catch(err => this.emit('error', err));
+    }
+  }
+}
+
+ZmqRaftPeerClient.PeerNotLeaderError = PeerNotLeaderError;
+ZmqRaftPeerClient.OutOfOrderError = OutOfOrderError;
+ZmqRaftPeerClient.ZmqRaftPeerClient = ZmqRaftPeerClient;
+ZmqRaftPeerClient.TimeoutError = TimeoutError;
+ZmqRaftPeerClient.RequestEntriesStream = RequestEntriesStream;
+module.exports = exports = ZmqRaftPeerClient;

--- a/lib/client/zmq_raft_peer_client.js
+++ b/lib/client/zmq_raft_peer_client.js
@@ -15,7 +15,6 @@ const { assertConstantsDefined, parsePeers } = require('../utils/helpers');
 const { bufferToLogEntry } = require('../common/log_entry');
 const { bufferToSnapshotChunk } = require('../common/snapshot_chunk');
 
-/* expect response within this timeout, if not will try the next server */
 const { SERVER_RESPONSE_TIMEOUT
 
       , RE_STATUS_NOT_LEADER
@@ -73,7 +72,7 @@ const debug = require('debug')('zmq-raft:peer-client');
 function PeerNotLeaderError(leaderId) {
   Error.captureStackTrace(this, PeerNotLeaderError);
   this.name = 'PeerNotLeaderError';
-  this.message = 'the responding peer is currently not a LEADER of its cluster';
+  this.message = 'the responding peer is currently not the LEADER of its cluster';
   this.leaderId = leaderId || null;
 }
 
@@ -92,31 +91,32 @@ OutOfOrderError.prototype.constructor = OutOfOrderError;
 OutOfOrderError.prototype.isOutOfOrder = true;
 
 /**
- * This client executes RPC calls on a single 0MQ Raft Peer.
- **/
+ * This client can be used to execute the 0MQ Raft RPC protocol on a single peer server.
+**/
 class ZmqRaftPeerClient extends ZmqProtocolSocket {
   /**
    * Create an instance of ZmqRaftPeerClient.
-   *
-   * `options` may be one of:
-   *
+   * 
+   * `options`:
+   * 
    * - `url` {string}: A single cluster peer url to connect directly to.
    * - `urls` {Array<string>}: An array of url peers; each request will be send to each one of them
    *                           in a round-robin order.
    * - `secret` {string|Buffer}: A cluster identifying string which is sent and verified against
    *                             in each message.
-   * - `timeout` {number}: A default time interval in milliseconds after which we consider a server
-   *                       unresponsive; the request will timeout if waiting for the response exceeds
-   *                       this interval; 0 disables request timeout - in this instance the response
-   *                       is waited for indefinitely; the default is 500 ms.
+   * - `timeout` {int32}: A default time interval in milliseconds after which we consider a server
+   *           peer to be unresponsive; if waiting for the response exceeds this interval the request
+   *           will timeout; 0 or negative disables request timeout - in this instance the response
+   *           is waited for indefinitely;
+   *           if undefined, the default is 500 ms.
    * - `lazy` {boolean}: Specify `true` to connect lazily on the first request.
-   * - `sockopts` {Object}: Specify zeromq socket options as an object e.g.: `{ZMQ_IPV4ONLY: true}`.
+   * - `sockopts` {Object}: Specify zeromq socket options as an object e.g.: {ZMQ_IPV4ONLY: true}.
    * - `highwatermark` {number}: A shortcut to specify `ZMQ_SNDHWM` socket option for an underlying
    *                   zeromq DEALER socket; this affects how many messages are queued per server
    *                   so if one of the peers goes down this many messages are possibly lost;
    *                   setting it prevents spamming a peer with expired messages when temporary
    *                   network partition occures (default: 2).
-   *
+   * 
    * @param {string|Array<string>} [urls]
    * @param {Object} [options]
    * @return {ZmqRaftPeerClient}
@@ -125,10 +125,13 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
     if (urls && !isArray(urls) && 'object' === typeof urls) {
       options = urls, urls = undefined;
     }
-    options || (options = {});
-    if (!options && 'object' !== typeof options)
-      throw TypeError('ZmqRaftPeerClient: options must be an object');
-    options = Object.assign({timeout: SERVER_RESPONSE_TIMEOUT}, options);
+
+    options = Object.assign({}, options);
+    if (options.timeout === undefined) {
+      options.timeout = SERVER_RESPONSE_TIMEOUT;
+    }
+
+    urls || (urls = options.urls || options.url);
 
     super(urls, options);
 
@@ -138,7 +141,7 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
 
   /**
    * Disconnect, close socket and reject all pending requests.
-   *
+   * 
    * @return {ZmqRaftPeerClient}
   **/
   close() {
@@ -149,11 +152,11 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
 
   /**
    * Create a cancellable time delay promise.
-   *
+   * 
    * The promise will resolve to the given `result` after the `ms` milliseconds.
    * If the client would be closed before the promise is resolved, the promise
    * will be rejected immediately with an Error.
-   *
+   * 
    * @param {number} ms - delay interval in milliseconds.
    * @param {any} [result] - the resolve argument.
    * @return {Promise}
@@ -176,12 +179,15 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
 
   /**
    * Invoke RequestConfig RPC.
-   *
-   * Resolves to {leaderId: string|null, isLeader: boolean, peers: [[id, url]]} on success.
-   *
-   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
-   *                 the request is abandoned and the promise is rejected with TimeoutError;
-   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * 
+   * The returned promise resolves to an Object with the following properties on success:
+   * - `leaderId` {string|null} - ID of the current LEADER, if it's known to the responding peer.
+   * - `isLeader` {boolean} - indicates the LEADER state of the responding peer.
+   * - `peers` {Array<[id, url]>} - the current cluster configuration.
+   * 
+   * @param {int32} [timeout] - an override for the response timeout in milliseconds;
+   *                the promise is rejected with TimeoutError on timeout;
+   *                if this is 0, null or undefined, default timeout is used instead.
    * @return {Promise}
   **/
   requestConfig(timeout) {
@@ -189,29 +195,27 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
         , options = {protocol: requestConfigProtocol, timeout};
 
     return this.request(msg, options)
-    .then(([isLeader, leaderId, peers]) => {
-      return {leaderId, isLeader, peers};
-    });
+    .then(([isLeader, leaderId, peers]) => ({leaderId, isLeader, peers}))
   }
 
   /**
    * Invoke RequestLogInfo RPC.
-   *
+   * 
    * The returned promise resolves to an Object with the following properties:
-   *
-   *  - isLeader {boolean}
-   *  - leaderId {string|null}
-   *  - currentTerm {number}
-   *  - firstIndex {number}
-   *  - lastApplied {number}
-   *  - commitIndex {number}
-   *  - lastIndex {number}
-   *  - snapshotSize {number}
-   *  - pruneIndex {number}
-   *
-   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
-   *                 the request is abandoned and the promise is rejected with TimeoutError;
-   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * 
+   *  - `isLeader` {boolean}
+   *  - `leaderId` {string|null}
+   *  - `currentTerm` {number}
+   *  - `firstIndex` {number}
+   *  - `lastApplied` {number}
+   *  - `commitIndex` {number}
+   *  - `lastIndex` {number}
+   *  - `snapshotSize` {number}
+   *  - `pruneIndex` {number}
+   * 
+   * @param {int32} [timeout] - an override for the response timeout in milliseconds;
+   *                the promise is rejected with TimeoutError on timeout;
+   *                if this is 0, null or undefined, default timeout is used instead.
    * @return {Promise}
   **/
   requestLogInfo(timeout) {
@@ -251,25 +255,25 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
 
   /**
    * Invoke ConfigUpdate RPC.
-   *
+   * 
    * The returned promise resolves to the log index of the committed entry of Cold,new on success.
-   *
+   * 
    * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
-   * raft state is other than the LEADER.
-   *
+   * current raft state is other than the LEADER.
+   * 
    * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
    * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
    * `id` should be freshly generated. Its "the seconds" part is important
    * because update requests might expire after `common.constants.DEFAULT_REQUEST_ID_TTL`
    * milliseconds.
-   *
+   * 
    * You may use `utils.id.genIdent()` function to generate them.
-   *
+   * 
    * @param {string|Buffer} id - a request ID to ensure idempotent updates.
    * @param {Array|Buffer} peers - the new cluster configuration.
-   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
-   *                 the request is abandoned and the promise is rejected with TimeoutError;
-   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * @param {int32} [timeout] - an override for the response timeout in milliseconds;
+   *                the promise is rejected with TimeoutError on timeout;
+   *                if this is 0, null or undefined, default timeout is used instead.
    * @return {Promise}
   **/
   configUpdate(id, peers, timeout) {
@@ -321,25 +325,25 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
 
   /**
    * Invoke RequestUpdate RPC.
-   *
+   * 
    * The returned promise resolves to the log index of the committed entry.
-   *
+   * 
    * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
-   * raft state is other than the LEADER.
-   *
+   * current raft state is other than the LEADER.
+   * 
    * `id` must be a 12 byte buffer or 24 byte unique hexadecimal string, following this:
    * https://docs.mongodb.com/manual/reference/method/ObjectId/ specification.
    * `id` should be freshly generated. Its "the seconds" part is important
    * because update requests might expire after `common.constants.DEFAULT_REQUEST_ID_TTL`
    * milliseconds.
-   *
+   * 
    * You may use `utils.id.genIdent()` function to generate them.
-   *
+   * 
    * @param {string|Buffer} id - a request ID to ensure idempotent updates.
    * @param {Buffer} data - log entry data to modify the state.
-   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
-   *                 the request is abandoned and the promise is rejected with TimeoutError;
-   *                 if this is 0, null or undefined, the default timeout is used instead.
+   * @param {int32} [timeout] - an override for the response timeout in milliseconds;
+   *                the promise is rejected with TimeoutError on timeout;
+   *                if this is 0, null or undefined, default timeout is used instead.
    * @return {Promise}
   **/
   requestUpdate(id, data, timeout) {
@@ -377,53 +381,52 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
 
   /**
    * Perform RequestEntries RPC.
-   *
-   * Retrieve entries using the `receiver` callback.
-   *
+   * 
+   * Retrieve RAFT log entries using the `receiver` callback.
+   * 
    * The received entries must be consumed ASAP and the retrieving of them can not be paused.
    * However it is possible to cancel the request while processing entries.
-   *
+   * 
    * Use ZmqRaftPeerClient.prototype.requestEntriesStream to work with the back-pressured streams instead.
-   *
+   * 
    * The returned promise will resolve to `true` if all of the requested entries were received.
    * Otherwise the promise will resolve to `false` if the request was canceled by the receiver.
-   *
+   * 
    * The promise is rejected with the PeerNotLeaderError if the server peer responds but its
-   * raft state is other than the LEADER. It may be possible even if some entries have been
-   * already received.
-   *
+   * current raft state is other than the LEADER. It may be possible even if some entries have
+   * been already received.
+   * 
    * If the promise is rejected with any error, that error will have a property `requestEntriesState`
    * set to a value with the following properties:
    * - lastIndex {number}
    * - [count] {number}
    * - [snapshotOffset] {number}
    * which can be used for the request continuation.
-   *
+   * 
    * The `receiver` function may modify its entries array argument (e.g. clear it).
    * The `receiver` may request to stop receiving entries if the function returns `false`
    * (that is an exact boolean `false`, not a falsy-ish value).
-   *
+   * 
    * The `receiver` function signature:
    *   (status: number, entries_or_snapshot_chunk: Array|Buffer, lastIndex: number,
    *    byteOffset?: number, snapshotSize?: number, isLastChunk?: boolean, snapshotTerm?: number
    *   ) => false|any
-   *
+   * 
    * The `status` in this case may be one of:
-   *
+   * 
    * - 1: this is the last batch.
    * - 2: expect more entries.
    * - 3: this is a snapshot chunk.
-   *
+   * 
    * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
    *                             (e.g. the index of the last received entry), specify 0 to start from 1.
    * @param {number} [count] - the maximum number of requested entries, only valid if > 0; otherwise ignored.
    * @param {Function} receiver - the function to process received entries.
-   * @param {number} [timeout] - an override timeout interval in milliseconds, after which
-   *                 the request is abandoned and the promise is rejected with TimeoutError;
-   *                 if this is 0, null or undefined, the default timeout is used instead;
-   *                 each received response restarts the timeout counter.
+   * @param {int32} [timeout] - an override for the response timeout in milliseconds;
+   *                            the promise is rejected with TimeoutError on timeout;
+   *                            if this is 0, null or undefined, default timeout is used instead.
    * @param {number} [snapshotOffset] - a hint for the server to start responding with snapshot chunks
-   *           starting from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
+   *         starting from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
    * @return {Promise}
   **/
   requestEntries(lastIndex, count, receiver, timeout, snapshotOffset) {
@@ -468,7 +471,9 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
                   snapshotSize = arg[1];
                   snapshotTerm = arg[2];
                   chunk = res[3];
-                  if (currentByte !== byteOffset) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: snapshot chunks received out of order");
+                  if (currentByte !== byteOffset) {
+                    throw new OutOfOrderError("requestEntries: snapshot chunks received out of order");
+                  }
                   currentByte = byteOffset + chunk.length;
                   isLastChunk = currentByte === snapshotSize;
                   ret = receiver(status, chunk, lastIndex, byteOffset, snapshotSize, isLastChunk, snapshotTerm);
@@ -496,7 +501,9 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
                   msg[2] = lastIndex;
                   res.splice(0, 3);
                   numEntries = res.length;
-                  if (lastIndex - numEntries !== prevIndex) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: log entries received out of order");
+                  if (lastIndex - numEntries !== prevIndex) {
+                    throw new OutOfOrderError("requestEntries: log entries received out of order");
+                  }
                   ret = receiver(status, res, lastIndex);
                   if (count !== undefined) msg[3] = (count -= numEntries);
                 }
@@ -552,30 +559,33 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
   }
 
   /**
-   * Returns a Readable stream that retrieves entries via the RequestEntries RPC.
-   *
+   * Returns a Readable stream that retrieves RAFT log entries via the RequestEntries RPC.
+   * 
    * The returned stream is lazy: RequestEntries RPC messages are sent to the cluster only when
    * data is requested via stream.Readable api.
-   *
+   * 
    * The returned stream can be back-pressured.
-   *
+   * 
    * The stream yields objects that are instances of either common.LogEntry or common.SnapshotChunk.
-   *
+   * 
+   * The stream will emit an "error" event with the PeerNotLeaderError if the server peer responds
+   * but its current raft state is other than the LEADER. It may be possible even if some entries have
+   * been already received.
+   * 
    * `options`:
-   *
+   * 
    * - `count` {number} - the maximum number of requested entries, only valid if > 0; otherwise ignored.
-   * - `timeout` {number} - an override timeout interval in milliseconds, after which the request
-   *                is abandoned and the stream will emit an "error" event with the TimeoutError argument;
-   *                if this is 0, null or undefined, the default timeout is used instead;
-   *                each received response restarts the timeout counter.
+   * - `timeout` {int32} - an override for the response timeout in milliseconds;
+   *                       the stream will emit an "error" event with TimeoutError on timeout;
+   *                       if this is 0, null or undefined, default timeout is used instead.
    * - `snapshotOffset` {number} - a hint for the server to start responding with snapshot chunks starting
    *                  from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
-   *
+   * 
    * Any other option is passed to the Readable constructor.
-   *
+   * 
    * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
    *                             (e.g. the index of the last received entry), specify 0 to start from 1.
-   * @param {number|Object} [count|options]
+   * @param {Object|number} [options|count]
    * @return {RequestEntriesStream}
   **/
   requestEntriesStream(lastIndex, options) {

--- a/lib/client/zmq_raft_peer_client.js
+++ b/lib/client/zmq_raft_peer_client.js
@@ -561,8 +561,8 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
   /**
    * Returns a Readable stream that retrieves RAFT log entries via the RequestEntries RPC.
    * 
-   * The returned stream is lazy: RequestEntries RPC messages are sent to the cluster only when
-   * data is requested via stream.Readable api.
+   * The returned stream is lazy: RequestEntries RPC messages are sent to the peer server only
+   * when data is requested via stream.Readable api.
    * 
    * The returned stream can be back-pressured.
    * 
@@ -647,7 +647,7 @@ class RequestEntriesStream extends Readable {
       .then(res => {
         if (res) {
           /* EOS */
-          debug("request entries stream end");
+          debug("request entries stream ends");
           this.push(null);
         }
         else { /* back-pressured */

--- a/lib/client/zmq_raft_peer_client.js
+++ b/lib/client/zmq_raft_peer_client.js
@@ -65,6 +65,7 @@ const ZmqProtocolSocket = require('../client/zmq_protocol_socket');
 const TimeoutError = ZmqProtocolSocket.TimeoutError;
 
 const secretBuf$ = Symbol('secretBuf');
+const timeout$   = Symbol('timeout');
 const request$ = Symbol('request');
 
 const debug = require('debug')('zmq-raft:peer-client');
@@ -132,6 +133,7 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
     super(urls, options);
 
     this[secretBuf$] = Buffer.from(options.secret || '');
+    this[timeout$] = new Set();
   }
 
   /**
@@ -139,9 +141,38 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
    *
    * @return {ZmqRaftPeerClient}
   **/
-  // close() {
-  //   return super.close();
-  // }
+  close() {
+    for(let cancel of this[timeout$]) cancel(new Error("closed"));
+    assert(this[timeout$].size === 0);
+    return super.close();
+  }
+
+  /**
+   * Create a cancellable time delay promise.
+   *
+   * The promise will resolve to the given `result` after the `ms` milliseconds.
+   * If the client would be closed before the promise is resolved, the promise
+   * will be rejected immediately with an Error.
+   *
+   * @param {number} ms - delay interval in milliseconds.
+   * @param {any} [result] - the resolve argument.
+   * @return {Promise}
+  **/
+  delay(ms, result) {
+    var ts = this[timeout$];
+    return new Promise((resolve, reject) => {
+      var cancel = (err) => {
+        clearTimeout(timeout);
+        ts.delete(cancel);
+        reject(err);
+      },
+      timeout = setTimeout(() => {
+        ts.delete(cancel);
+        resolve(result)
+      }, ms);
+      ts.add(cancel);
+    });
+  };
 
   /**
    * Invoke RequestConfig RPC.

--- a/lib/client/zmq_raft_peer_client.js
+++ b/lib/client/zmq_raft_peer_client.js
@@ -72,7 +72,7 @@ const debug = require('debug')('zmq-raft:peer-client');
 function PeerNotLeaderError(leaderId) {
   Error.captureStackTrace(this, PeerNotLeaderError);
   this.name = 'PeerNotLeaderError';
-  this.message = 'the peer is not the leader';
+  this.message = 'the responding peer is currently not a LEADER of its cluster';
   this.leaderId = leaderId || null;
 }
 
@@ -184,6 +184,9 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
    * @return {Promise}
   **/
   requestLogInfo(timeout) {
+    if (arguments.length === 2) { /* allow ZmqRaftClient API call */
+      timeout = arguments[1];
+    }
     const msg = [requestLogInfoTypeBuf, this[secretBuf$]]
         , options = {protocol: requestLogInfoProtocol, timeout};
 
@@ -434,7 +437,7 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
                   snapshotSize = arg[1];
                   snapshotTerm = arg[2];
                   chunk = res[3];
-                  if (currentByte !== byteOffset) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: snapshot chunks not in order");
+                  if (currentByte !== byteOffset) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: snapshot chunks received out of order");
                   currentByte = byteOffset + chunk.length;
                   isLastChunk = currentByte === snapshotSize;
                   ret = receiver(status, chunk, lastIndex, byteOffset, snapshotSize, isLastChunk, snapshotTerm);
@@ -462,7 +465,7 @@ class ZmqRaftPeerClient extends ZmqProtocolSocket {
                   msg[2] = lastIndex;
                   res.splice(0, 3);
                   numEntries = res.length;
-                  if (lastIndex - numEntries !== prevIndex) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: entries not in order");
+                  if (lastIndex - numEntries !== prevIndex) throw new OutOfOrderError("ZmqRaftPeerClient.requestEntries: log entries received out of order");
                   ret = receiver(status, res, lastIndex);
                   if (count !== undefined) msg[3] = (count -= numEntries);
                 }

--- a/lib/client/zmq_raft_peer_sub.js
+++ b/lib/client/zmq_raft_peer_sub.js
@@ -81,7 +81,7 @@ const debug = require('debug')('zmq-raft:peer-sub');
  * ZmqRaftPeerSub extends the single peer 0MQ Raft RPC protocol, providing a subscriber socket
  * that connects to the BroadcastStateMachine for the current RAFT log and state notifications.
  *
- * Inherits all the ZmqRaftPeerClient functions and provides additional methods related to BSM.
+ * Inherits all of the ZmqRaftPeerClient methods and provides additional functions related to BSM.
  *
  * ZmqRaftPeerSub also emits the following events (as EventEmitter):
  *
@@ -109,8 +109,8 @@ class ZmqRaftPeerSub extends ZmqRaftPeerClient {
    *                             in each message.
    * - `timeout` {int32}: A default time interval in milliseconds after which we consider a server
    *           peer to be unresponsive; if waiting for the response exceeds this interval the request
-   *           will timeout; 0 or negative disables request timeout - in this instance the response
-   *           is waited for indefinitely;
+   *           will timeout; 0 or less than 0 disables the request timeout - in this instance the
+   *           response is waited for indefinitely;
    *           if undefined, the default is 500 ms.
    * - `broadcastTimeout` {int32}: The number of milliseconds before the BSM is considered unresponsive
    *                               (default: 1 second).
@@ -237,7 +237,6 @@ class ZmqRaftPeerSub extends ZmqRaftPeerClient {
         const urlbuf = resp[0];
         if (isBuffer(urlbuf)) return urlbuf.toString();
       }
-      console.log(resp)
       throw new Error("broadcast state url missing in the response");
     });
   }
@@ -247,8 +246,8 @@ class ZmqRaftPeerSub extends ZmqRaftPeerClient {
    *
    * Calling this method stops "pulse" events and will also prevent "timeout" events.
    *
-   * After calling this method, a call to `subscribe()` is explicitly needed to resume
-   * the subscription.
+   * After calling this method, a call to `subscribe()` is explicitly needed to reconnect
+   * and re-subscribe the socket.
   **/
   unsubscribe() {
     const sub = this.sub
@@ -337,9 +336,9 @@ class ZmqRaftPeerSub extends ZmqRaftPeerClient {
    * Returns a Readable stream that retrieves RAFT log entries via the combination of
    * RequestEntries RPC and notifications from BroadcastStateMachine.
    *
-   * The stream ends when the RAFT peer (that this client is connected to) is not a LEADER.
-   * Otherwise the stream, after pushing all the present requested log entries waits for the future
-   * updates via BSM notifications and pushes all incoming new entries.
+   * The stream ends when the RAFT peer (that this client connects to) is not a LEADER.
+   * Otherwise, the stream, after pushing all the present requested log entries, waits
+   * for the future updates via BSM notifications, and pushes all incoming new entries.
    * 
    * The returned stream is lazy: RequestEntries RPC messages are sent to the peer server only
    * when data is requested via stream.Readable api.
@@ -503,7 +502,7 @@ class ForeverEntriesStream extends Readable {
       this._rlStream.resume();
     }
     else if (!client.isLeader || this.sentIndex < client.lastLogIndex) {
-      this._recvMissingEntries(); // if not a LEADER this will trigger the stream to end
+      this._recvMissingEntries(); // if not really a LEADER this will trigger the stream to end
     }
   }
 

--- a/lib/client/zmq_raft_peer_sub.js
+++ b/lib/client/zmq_raft_peer_sub.js
@@ -1,0 +1,545 @@
+/* 
+ *  Copyright (c) 2020 Rafał Michalski <royal@yeondir.com>
+ */
+"use strict";
+
+/*
+
+Example:
+
+  let client = new ZmqRaftPeerSub('tcp://127.0.0.1:8047', {broadcastTimeout: 250, lazy: true})
+    .on('error', err => console.error(err))
+    .on('pub', url => console.log("got PUB url: %s", url))
+    .on('pulse', (lastTx, term, entries) => {
+      console.log("got a pulse: last tx: %s term: %s new entries: %s", lastTx, term, entries.length)
+    })
+    .on('timeout', () => console.log("no heartbeat, an election is pending or the peer is down"))
+    .on('close', () => console.log("client was closed"))
+
+  client.close(); // shutdown all pending requests, streams and sockets
+
+  // forever tx stream
+
+  let subs = client.foreverEntriesStream(lastIndex, {timeout, snapshotOffset});
+
+  subs.on('data', (entry) => {
+    //...
+  })
+  .on('error', err => {
+    if (err.isTimeout) {
+      console.error("the peer is down");
+    }
+    else {
+      console.error(err)
+    }
+  })
+  .on('end', err => console.log("the peer is not a leader anymore"))
+  .on('close', err => console.log("streaming closed"))
+
+  // to shut this log stream down and free resources, when no longer needed
+  subs.destroy(); 
+*/
+const isArray  = Array.isArray
+    , isBuffer = Buffer.isBuffer
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { Readable } = require('stream');
+
+const { ZMQ_LINGER } = require('zeromq');
+const { ZmqSocket } = require('../utils/zmqsocket');
+
+const { assertConstantsDefined } = require('../utils/helpers');
+
+const { bufferToLogEntry } = require('../common/log_entry');
+
+const { BROADCAST_HEARTBEAT_INTERVAL
+      } = require('../common/constants');
+
+assertConstantsDefined({
+  BROADCAST_HEARTBEAT_INTERVAL
+}, 'number');
+
+const DEFAULT_BROADCAST_TIMEOUT = BROADCAST_HEARTBEAT_INTERVAL * 2;
+const BROADCAST_TIMEOUT_MIN = 100;
+
+const REQUEST_URL_MSG_TYPE = '*';
+
+const requestUrlTypeBuf  = Buffer.from(REQUEST_URL_MSG_TYPE);
+
+const ZmqRaftPeerClient = require('../client/zmq_raft_peer_client');
+
+const secretBuf$ = Symbol('secretBuf');
+
+const { createFramesProtocol } = require('../protocol');
+
+const stateBroadcastProtocol = createFramesProtocol('StateBroadcast');
+
+const debug = require('debug')('zmq-raft:peer-sub');
+
+/**
+ * ZmqRaftPeerSub extends the single peer 0MQ Raft RPC protocol, providing a subscriber socket
+ * that connects to the BroadcastStateMachine for the current RAFT log and state notifications.
+ *
+ * Inherits all the ZmqRaftPeerClient functions and provides additional methods related to BSM.
+ *
+ * ZmqRaftPeerSub also emits the following events (as EventEmitter):
+ *
+ * - "error" (Error) - when an error occured while trying to subscribe to the BSM.
+ * - "close" () - when the client instance is being closed; this event is being used to shut down
+ *                all pending ForeverEntriesStream instances.
+ * - "pub" (url: string) - emitted when the BSM publisher's `url` has been discovered.
+ * - "pulse" (lastIndex: number, currentTerm: number, entries: Array) - emitted when a notification
+ *           arrives from the BSM.
+ * - "timeout" () - emitted when the BSM didn't sent a notification for the period of time exceeding
+ *                  `broadcastTimeout`. This event is emitted only once, after the last received
+ *                  notification or after subscribing to the BSM publisher socket.
+ *                  It's possible to extend the timeout period by calling `refreshPulseTimeout()`.
+**/
+class ZmqRaftPeerSub extends ZmqRaftPeerClient {
+  /**
+   * Create ZmqRaftPeerSub
+   *
+   * `options` may be one of:
+   *
+   * - `url` {string}: A single cluster peer url to connect directly to.
+   * - `urls` {Array<string>}: An array of url peers; each request will be send to each one of them
+   *                           in a round-robin order.
+   * - `secret` {string|Buffer}: A cluster identifying string which is sent and verified against
+   *                             in each message.
+   * - `timeout` {int32}: A default time interval in milliseconds after which we consider a server
+   *           peer to be unresponsive; if waiting for the response exceeds this interval the request
+   *           will timeout; 0 or negative disables request timeout - in this instance the response
+   *           is waited for indefinitely;
+   *           if undefined, the default is 500 ms.
+   * - `broadcastTimeout` {int32}: The number of milliseconds before the BSM is considered unresponsive
+   *                               (default: 1 second).
+   * - `lazy` {boolean}: Specify `true` to connect lazily on the first request.
+   * - `sockopts` {Object}: Specify zeromq socket options as an object e.g.: `{ZMQ_IPV4ONLY: true}`.
+   * - `highwatermark` {number}: A shortcut to specify `ZMQ_SNDHWM` socket option for an underlying
+   *                   zeromq DEALER socket; this affects how many messages are queued per server
+   *                   so if one of the peers goes down this many messages are possibly lost;
+   *                   setting it prevents spamming a peer with expired messages when temporary
+   *                   network partition occures (default: 2).
+   *
+   * @param {string|Array<string>} [urls]
+   * @param {Object} [options]
+   * @return {ZmqRaftPeerSub}
+  **/
+  constructor(urls, options) {
+    if (urls && !isArray(urls) && 'object' === typeof urls) {
+      options = urls, urls = undefined;
+    }
+    options = Object.assign({lazy: false}, options);
+
+    var broadcastTimeoutMs = (options.broadcastTimeout|0) || DEFAULT_BROADCAST_TIMEOUT;
+    if (broadcastTimeoutMs < BROADCAST_TIMEOUT_MIN) {
+      broadcastTimeoutMs = BROADCAST_TIMEOUT_MIN;
+    }
+
+    super(urls, options);
+    EventEmitter.call(this);
+
+    this.broadcastTimeoutMs = broadcastTimeoutMs;
+    debug('broadcast timeout: %s ms.', broadcastTimeoutMs);
+
+    this[secretBuf$] = Buffer.from(options.secret || '');
+    this.url = null;
+    this.lastLogIndex = 0;
+    this.currentTerm = 0;
+    this.isLeader = false;
+
+    var sub = this.sub = new ZmqSocket('sub');
+    /* makes sure socket is really closed when close() is called */
+    sub.setsockopt(ZMQ_LINGER, 0);
+
+    this._listener = stateBroadcastProtocol.createSubMessageListener(sub, handleBroadcast, this);
+    this._pulseTimeout = null;
+    this._subscribing = null;
+
+    if (!options.lazy) {
+      this.subscribe().catch(err => this.emit('error', err));
+    }
+  }
+
+  /**
+   * The last known publisher url. Updated after a successfull discovery request.
+   * @property url {string|null}
+  **/
+
+  /**
+   * The last known peer's log index. Updated before emitting each "pulse" event.
+   * @property lastLogIndex {number}
+  **/
+
+  /**
+   * The last known peer's current term. Updated before emitting each "pulse" event.
+   * @property currentTerm {number}
+  **/
+
+  /**
+   * The last known peer's state. Updated before emitting each "pulse" or "timeout" event.
+   * @property isLeader {boolean}
+  **/
+
+  toString() {
+    var url = this.url;
+    return `[object ZmqRaftPeerSub{${(url || '-none-')}}]`;
+  }
+
+  /**
+   * Disconnect, close socket and reject all pending requests.
+   *
+   * This also closes all instances of ForeverEntriesStream.
+   * 
+   * @return {ZmqRaftPeerSub}
+  **/
+  close() {
+    const sub = this.sub;
+    if (!sub) return this;
+    this.sub = null;
+    clearTimeout(this._pulseTimeout);
+    this._pulseTimeout = null;
+    sub.unsubscribe(this[secretBuf$]);
+    if (this.url != null) {
+      debug('sub.disconnect: %s', this.url)
+      try {
+        sub.disconnect(this.url);
+      }
+      catch(_e) {/* ignore */}
+    }
+    sub.removeListener('frames', this._listener);
+    sub.close();
+    try {
+      this.emit('close');
+    }
+    catch(err) {
+      console.error(err);
+    }
+    debug('subscriber closed');
+    return super.close();
+  }
+
+  /**
+   * Discover BroadcastStateMachine publisher's URL.
+   * 
+   * The returned promise resolves to a string with the publisher's url.
+   * 
+   * @param {int32} [timeout] - an override for the response timeout in milliseconds;
+   *                the promise is rejected with TimeoutError on timeout;
+   *                if this is 0, null or undefined, default timeout is used instead.
+   * @return {Promise}
+  **/
+  requestBroadcastStateUrl(timeout) {
+    return this.request([requestUrlTypeBuf, this[secretBuf$]], { timeout })
+    .then(resp => {
+      if (isArray(resp) && resp.length === 1) {
+        const urlbuf = resp[0];
+        if (isBuffer(urlbuf)) return urlbuf.toString();
+      }
+      console.log(resp)
+      throw new Error("broadcast state url missing in the response");
+    });
+  }
+
+  /**
+   * Unsubscribe from the BroadcastStateMachine publisher's socket.
+   *
+   * Calling this method stops "pulse" events and will also prevent "timeout" events.
+   *
+   * After calling this method, a call to `subscribe()` is explicitly needed to resume
+   * the subscription.
+  **/
+  unsubscribe() {
+    const sub = this.sub
+        , url = this.url;
+    if (url && sub) {
+      debug('sub.disconnect: %s', this.url)
+      try {
+        sub.disconnect(this.url);
+      }
+      catch(_e) {/* ignore */}
+      sub.unsubscribe(this[secretBuf$]);
+      clearTimeout(this._pulseTimeout);
+      this._pulseTimeout = null;
+    }
+  }
+
+  /**
+   * Subscribe to the BroadcastStateMachine publisher's socket.
+   *
+   * May attempt to discover the publisher's `url`. In this instance the `timeout` parameter
+   * is used for the discovery RPC.
+   *
+   * The returned promise resolves to the BSM publisher's URL.
+   *
+   * @return {Promise}
+  **/
+  subscribe(timeout) {
+    if (this._subscribing) return this._subscribing;
+
+    const sub = this.sub
+        , url = this.url;
+
+    if (!sub) return Promise.reject(new Error("ZmqRaftPeerSub.subscribe: already closed"));
+
+    if (url) {
+      if ('string' !== typeof url) {
+        return Promise.reject(new TypeError("ZmqRaftPeerSub.subscribe: url must be a string or a buffer"));
+      }
+      debug('subscriber.connect: %s', url);
+      sub.connect(url);
+      sub.subscribe(this[secretBuf$]);
+      clearTimeout(this._pulseTimeout);
+      this._pulseTimeout = true;
+      this.refreshPulseTimeout();
+      return Promise.resolve(url);
+    }
+
+    return this._subscribing = this.requestBroadcastStateUrl(timeout)
+    .then(url => {
+      this.url = url;
+      this._subscribing = null;
+      try {
+        this.emit('pub', url);
+      } catch(err) {
+        console.error(err)
+      }
+      return this.subscribe(timeout);
+    },
+    err => {
+      this._subscribing = null;
+      throw err;
+    });
+  }
+
+  /**
+   * Restart BroadcastStateMachine timeout counter.
+  **/
+  refreshPulseTimeout() {
+    if (this._pulseTimeout) {
+      clearTimeout(this._pulseTimeout);
+      if (this.sub === null) return;
+      this._pulseTimeout = setTimeout(() => {
+        debug('broadcast timeout');
+        this.isLeader = false;
+        try {
+          this.emit('timeout');
+        }
+        catch(err) {
+          this.emit('error', err);
+        }
+      }, this.broadcastTimeoutMs);
+    }
+  }
+
+  /**
+   * Returns a Readable stream that retrieves RAFT log entries via the combination of
+   * RequestEntries RPC and notifications from BroadcastStateMachine.
+   *
+   * The stream ends when the RAFT peer (that this client is connected to) is not a LEADER.
+   * Otherwise the stream, after pushing all the present requested log entries waits for the future
+   * updates via BSM notifications and pushes all incoming new entries.
+   * 
+   * The returned stream is lazy: RequestEntries RPC messages are sent to the peer server only
+   * when data is requested via stream.Readable api.
+   * 
+   * The returned stream can be back-pressured.
+   *
+   * The stream yields objects that are instances of either common.LogEntry or common.SnapshotChunk.
+   * 
+   * NOTICE: If the stream is no longer needed, call its `destroy()` method (from Readable api).
+   *         Otherwise, it will leak resources. There is no need to call this method if the stream
+   *         ends (because of the peer's LEADER state change) or emits an error.
+   * 
+   * `options`:
+   * 
+   * - `timeout` {int32} - an override for the response timeout in milliseconds;
+   *                       the stream will emit an "error" event with TimeoutError on timeout;
+   *                       if this is 0, null or undefined, default timeout is used instead.
+   * - `snapshotOffset` {number} - a hint for the server to start responding with snapshot chunks starting
+   *                  from this byte offset, providing the `lastIndex` precedes the actual snapshot index.
+   * 
+   * Any other option is passed to the Readable constructor.
+   * 
+   * @param {number} lastIndex - index of the log entry PRECEDING entries that are actually requested
+   *                             (e.g. the index of the last received entry), specify 0 to start from 1.
+   * @param {Object} [options]
+   * @return {ForeverEntriesStream}
+  **/
+  foreverEntriesStream(lastIndex, options) {
+    if (!this.url) {
+      this.subscribe().catch(err => this.emit('error', err));
+    }
+    return new ForeverEntriesStream(this, lastIndex, options);
+  }
+}
+
+function handleBroadcast(args) {
+  const [secret, term, lastIndex] = args.splice(0, 3)
+      , entries = args;
+
+  if (!this[secretBuf$].equals(secret)) {
+    return this.emit('error', new Error('ZmqRaftPeerSub: broadcast authentication fails'));
+  }
+
+  this.lastLogIndex = lastIndex;
+  this.currentTerm = term;
+  this.isLeader = true;
+
+  this.refreshPulseTimeout();
+
+  try {
+    this.emit('pulse', lastIndex, term, entries);
+  }
+  catch(err) {
+    this.emit('error', err);
+  }
+}
+
+/* ZmqRaftPeerSub mixin EventEmitter */
+for (let prop in EventEmitter.prototype) {
+  ZmqRaftPeerSub.prototype[prop] = EventEmitter.prototype[prop];
+}
+
+class ForeverEntriesStream extends Readable {
+  constructor(client, lastIndex, options) {
+    var {timeout, snapshotOffset} = options || {}; // TODO: count perhaps?
+
+    super(Object.assign({}, options, {objectMode: true}));
+
+    this.client = client;
+    this.isFlowing = false;
+    this._ahead = [];
+    this._rlStream = null;
+
+    if (lastIndex === undefined) lastIndex = 0;
+    else if (!Number.isFinite(lastIndex) || lastIndex < 0 || lastIndex % 1 !== 0) {
+      throw new Error("ForeverEntriesStream: lastIndex must be an unsigned integer");
+    }
+
+    this.sentIndex = lastIndex;
+
+    client.on('error', this._errorHandler = (err) => this.destroy(err));
+    client.on('close', this._closeHandler = () => this.destroy());
+    client.on('timeout', this._timeoutHandler = () => {
+      // trigger missing entries so we can determine if the peer is really down or is not a leader
+      this._recvMissingEntries();
+    });
+
+    this._pulseHandler = (lastIndex, _term, entries) => {
+      var pushedEntries = false;
+      if (this._rlStream == null) {
+        pushedEntries = this._pushEntries(lastIndex, entries);
+      }
+      if (pushedEntries === false && lastIndex > this.sentIndex) {
+        if (entries.length !== 0) this._ahead.push({lastIndex, entries});
+        this._recvMissingEntries();
+      }
+    };
+
+    this._recvMissingEntries = () => {
+      if (this._rlStream != null) return;
+      debug("recv missing entries since: %s", this.sentIndex);
+      this._rlStream = client.requestEntriesStream(this.sentIndex, {timeout, snapshotOffset})
+      .on('data', chunk => {
+        var logIndex = chunk.logIndex;
+        if (logIndex > this.sentIndex) {
+          if (chunk.isLogEntry || chunk.isLastChunk) {
+            this.sentIndex = logIndex;
+            snapshotOffset = 0;
+          }
+          else if (chunk.isSnapshotChunk) {
+            snapshotOffset = chunk.snapshotByteOffset + chunk.length;
+          }
+          if (!this.push(chunk)) {
+            this._stopFlow();
+          }
+        }
+      })
+      .on('end', () => {
+        this._rlStream = null;
+        // flush ahead
+        while (this._ahead.length !== 0) {
+          let {lastIndex, entries} = this._ahead.shift();
+          this._pushEntries(lastIndex, entries);
+        }
+      })
+      .on('error', err => { //TODO: think if should handle out of order?
+        this._rlStream = null;
+        if (err.isPeerNotLeader) {
+          debug("recessed peer - no more a LEADER, forever ends");
+          this.push(null); // peer is not a LEADER anymore, just end the stream
+        }
+        else {
+          this.destroy(err);
+        }
+      })
+    }
+
+  }
+
+  _destroy(err, callback) {
+    const client = this.client;
+    this.isFlowing = null;
+    client.removeListener('error', this._errorHandler);
+    client.removeListener('close', this._closeHandler);
+    client.removeListener('timeout', this._timeoutHandler);
+    client.removeListener('pulse', this._pulseHandler);
+    if (this._rlStream) {
+      this._rlStream.destroy(err);
+      this._rlStream = null;
+    }
+    callback(err);
+  }
+
+  _read(_size) {
+    const client = this.client;
+    if (!this.isFlowing) {
+      this.isFlowing = true;
+      client.on('pulse', this._pulseHandler);
+    }
+    if (this._rlStream) {
+      this._rlStream.resume();
+    }
+    else if (!client.isLeader || this.sentIndex < client.lastLogIndex) {
+      this._recvMissingEntries(); // if not a LEADER this will trigger the stream to end
+    }
+  }
+
+  _stopFlow() {
+    if (this.isFlowing) {
+      this.isFlowing = false;
+      this.client.removeListener('pulse', this._pulseHandler);
+      if (this._rlStream) {
+        this._rlStream.pause();
+      }
+      this._ahead.length = 0;
+    }
+  }
+
+  // returns num entries pushed, or false on index mismatch
+  _pushEntries(lastIndex, entries) {
+    const numEntries = entries.length;
+    var more = true;
+    var index = lastIndex - numEntries;
+
+    if (index === this.sentIndex) {
+      for(let i = 0; i < numEntries; ++i) {
+        more = this.push( bufferToLogEntry(entries[i], ++index) );
+      }
+      this.sentIndex = lastIndex;
+      if (!more) {
+        this._stopFlow();
+      }
+      return numEntries;
+    }
+    else {
+      return false;
+    }
+  }
+}
+
+ZmqRaftPeerSub.ZmqRaftPeerSub = ZmqRaftPeerSub;
+ZmqRaftPeerSub.ForeverEntriesStream = ForeverEntriesStream;
+module.exports = exports = ZmqRaftPeerSub;

--- a/lib/server/broadcast_state_machine.js
+++ b/lib/server/broadcast_state_machine.js
@@ -113,7 +113,7 @@ class BroadcastStateMachine extends FilePersistence {
 
     this.on('client-request', (reply, msgType) => {
       if (msgType.length === 1 && msgType[0] === REQUEST_URL_MATCH) {
-        if (this.isLeader) reply(this._urlBuf); else reply();
+        reply(this._urlBuf);
       }
     });
 

--- a/lib/utils/monitor.js
+++ b/lib/utils/monitor.js
@@ -86,8 +86,7 @@ class ZmqRaftMonitor extends EventEmitter {
       .then(result => {
         this.bootstrapClient.destroy();
         this.bootstrapClient = null;
-        return result ? result
-                      : Promise.reject(new TimeoutError())
+        return result
       });
     }
 

--- a/lib/utils/monitor.js
+++ b/lib/utils/monitor.js
@@ -2,7 +2,9 @@ const EventEmitter = require('events');
 const debug = require('debug')('zmq-raft-monitor');
 const { createRangeRandomizer } = require('./helpers');
 const ZmqRaftClient = require('../client/zmq_raft_client');
+const ZmqRaftPeerClient = require('../client/zmq_raft_peer_client');
 const TimeoutError = ZmqRaftClient.TimeoutError;
+const { parsePeers } = require('../utils/helpers');
 
 const REQUEST_CONFIG_TIMEOUT = 10000; // 10 seconds
 const REQUEST_INFO_TIMEOUT = 4000; // 4 seconds
@@ -18,11 +20,13 @@ class ZmqRaftMonitor extends EventEmitter {
    *
    * - `url` {String}: A seed url to fetch peer urls from via a Request Config RPC.
    * - `urls` {Array}: An array of seed urls to fetch peers from via a Request Config RPC.
-   * - `peers` {Array}: An array of established zmq raft server descriptors;
-   *                    `peers` has precedence over `urls` and if provided the peer list
-   *                    is not being fetched via Request Config RPC.
+   * - `peers` {Array<[id,url]>|{id: url}}: An array or an Object map of established zmq raft server
+   *                 descriptors; `peers` has precedence over `urls` and if provided the peer list
+   *                 is not being fetched via Request Config RPC.
    * - `secret` {String|Buffer}: A cluster identifying string which is sent and verified against
    *                             in each message.
+   * - `urlsOnly` {boolean}: if `true` the monitor will only connect to the peer urls provided in
+   *               the `url` or `urls` option, otherwise all of the cluster peers will be monitored.
    * - `sockopts` {Object}: Specify zeromq socket options as an object e.g.: `{ZMQ_IPV4ONLY: true}`.
    * - `serverElectionGraceDelay` {number}: A delay in milliseconds to wait for the Raft peers
    *                                     to elect a new leader before retrying (default: 300 ms).
@@ -67,50 +71,70 @@ class ZmqRaftMonitor extends EventEmitter {
     debug('query delay first: %s ms', options.queryDelayFirst);
     debug('query delay step: %s ms', options.queryDelayStep);
 
-    const bootstrapClient = this.bootstrapClient = new ZmqRaftClient( options );
+    var peersPromise;
+    this.bootstrapClient = null;
 
-    bootstrapClient.requestConfig(options.requestConfigTimeout)
-    .then(result => {
-      return result ? result
-                    : Promise.reject(new TimeoutError())
-    })
-    .then(({leaderId, urls}) => {
-      this.bootstrapClient = null;
-      bootstrapClient.destroy();
+    if (options.peers) {
+      const peers = parsePeers(options.peers);
+      const urls = {};
+      for (let [id, url] of peers) urls[id] = url;
+      peersPromise = Promise.resolve({leaderId: null, urls});
+    }
+    else {
+      this.bootstrapClient = new ZmqRaftClient( options );
+      peersPromise = this.bootstrapClient.requestConfig(options.requestConfigTimeout)
+      .then(result => {
+        this.bootstrapClient.destroy();
+        this.bootstrapClient = null;
+        return result ? result
+                      : Promise.reject(new TimeoutError())
+      });
+    }
 
+    peersPromise.then(({leaderId, urls}) => {
       const intervalRandomizer = createRangeRandomizer(options.requestInfoInterval,
                                                        options.requestInfoInterval * 2);
 
-      let graceDelay = options.queryDelayFirst;
+      var graceDelay = options.queryDelayFirst;
+
+      var seedUrlSet;
+      if (options.urlsOnly) {
+        debug('monitoring only selected peers');
+        seedUrlSet = new Set([].concat(options.urls || options.url));
+      }
 
       for (const peerId in urls) {
-        const peerOpts = Object.assign({}, options, { peers: [[peerId, urls[peerId]]] });
-        const peerClient = new ZmqRaftClient( peerOpts );
-        const query = (ms) => peerClient.delay( ms )
-        .then(() => {
-          if (peerClient.socket) {
-            return peerClient.requestLogInfo(true, options.requestInfoTimeout)
-            .then(info => {
-              this.emit('info', peerId, info);
-              return query(intervalRandomizer())
-            },
-            err => {
-              this.emit('peer-error', peerId, err);
-              return query(intervalRandomizer())
-            });
-          }
-        });
-        this.clients.set( peerId, peerClient );
-        query(graceDelay);
-        graceDelay += options.queryDelayStep;
+        const peerOpts = Object.assign({}, options);
+        const peerClient = new ZmqRaftPeerClient( urls[peerId], peerOpts );
+        if (!seedUrlSet || seedUrlSet.has(urls[peerId])) {
+          const query = (ms) => peerClient.delay( ms )
+          .then(() => {
+            if (peerClient.socket) {
+              return peerClient.requestLogInfo(options.requestInfoTimeout)
+              .then(info => {
+                this.emit('info', peerId, info);
+                return query(intervalRandomizer())
+              },
+              err => {
+                this.emit('peer-error', peerId, err);
+                return query(intervalRandomizer())
+              });
+            }
+          });
+          this.clients.set( peerId, peerClient );
+          query(graceDelay);
+          graceDelay += options.queryDelayStep;
+        }
       }
 
       this.emit('peers', urls, leaderId);
     })
     .catch(err => {
       debug('error retrieving cluster config, terminating: %s', err);
-      this.bootstrapClient = null;
-      bootstrapClient.destroy();
+      if (this.bootstrapClient) {
+        this.bootstrapClient.destroy();
+        this.bootstrapClient = null;
+      }
       this.emit('error', err);
     });
   }

--- a/lib/utils/repl_helpers.js
+++ b/lib/utils/repl_helpers.js
@@ -17,7 +17,14 @@ exports.listPeers = function listPeers(client) {
     return Promise.resolve();
   }
   return client.requestConfig(5000).then(peers => {
+    if (!peers.urls) { /* peer client */
+      peers.urls = {};
+      peers.peers.forEach(([id,url]) => { peers.urls[id]=url; });
+    }
     console.log(magenta('Cluster peers:'))
+    if (!peers.isLeader) {
+      console.log(yellow('(not authoritative answer from: %s)'), client.urls[0]);
+    }
     for(let id in peers.urls) {
       let url = peers.urls[id];
       if (id === peers.leaderId) {
@@ -35,13 +42,18 @@ exports.showInfo = function showInfo(client, id) {
     return Promise.resolve();
   }
   var cleanUp, anyPeer = false;
-  if (client.peers.has(id)) {
+  if (client.peers && client.peers.has(id)) {
     client = new ZmqRaftClient({peers: [[id, client.peers.get(id)]]});
     cleanUp = () => client.close();
     anyPeer = true;
   }
   else if (id) {
-    console.log(yellow('unknown id: %s'), id);
+    if (!client.peers) {
+      console.log(yellow("with the peer-client you may only query the peer you are connected to"));
+    }
+    else {
+      console.log(yellow("unknown id: %s"), id);
+    }
     return Promise.resolve();
   }
   else {
@@ -50,8 +62,8 @@ exports.showInfo = function showInfo(client, id) {
 
   return client.requestLogInfo(anyPeer, 5000)
   .then(({isLeader, leaderId, currentTerm, firstIndex, lastApplied, commitIndex, lastIndex, snapshotSize, pruneIndex}) => {
-    if (!anyPeer) assert(isLeader);
-    console.log(grey(`Log information for: "${isLeader ? green(leaderId) : yellow(id)}"`));
+    // if (!anyPeer) assert(isLeader);
+    console.log(grey(`Log information for: "${isLeader ? green(leaderId) : yellow(id||client.urls[0])}"`));
     console.log(`leader:          ${isLeader ? green('yes') : cyan('no')}`);
     console.log(`current term:    ${magenta(lpad(currentTerm, 14))}`);
     console.log(`first log index: ${magenta(lpad(firstIndex, 14))}`);


### PR DESCRIPTION
* Rework of ZmqRaftClient, split between ZmqRaftPeerClient and ZmqRaftClient (backward compatible with current client API)
* New ZmqRaftPeerSub client with the "Forever streaming" ability.
* BroadcastStateMachine always announces its PUB URL, regardless of the peer's RAFT state.
